### PR TITLE
Migration part 1

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+- name: Join the CNCF Slack and access our meetings.
+  url: https://www.kubeflow.org/docs/about/community/
+  about: Join our CNCF Slack Channel and access Kubeflow community meetings.
+- name: Our channel on the CNCF Slack is kubeflow-platform.
+  url: https://app.slack.com/client/T08PSQ7BQ/C073W572LA2
+  about: You can join our channel on the CNCF slack.

--- a/.github/ISSUE_TEMPLATE/issue-report.yml
+++ b/.github/ISSUE_TEMPLATE/issue-report.yml
@@ -1,0 +1,66 @@
+name: Issue Report
+description: Report an Issue
+body:
+- type: markdown
+  attributes:
+    value: |
+      Please provide the following details to help us diagnose and fix the issue effectively.
+- type: markdown
+  attributes:
+    value: |
+      Follow the [Kubeflow installation guidelines](https://github.com/kubeflow/manifests/blob/master/README.md) before submitting the report.
+- type: checkboxes
+  id: Vaildation
+  attributes:
+    label: Validation Checklist
+    options:
+    - label: I confirm that this is a Kubeflow-related issue.
+      required: true
+    - label: I am reporting this in the appropriate repository.
+      required: true
+    - label: I have followed the [Kubeflow installation guidelines](https://github.com/kubeflow/manifests/blob/master/README.md).
+      required: true
+    - label: The issue report is detailed and includes version numbers where applicable.
+      required: true
+    - label: This issue pertains to Kubeflow development.
+      required: false
+    - label: I am available to work on this issue.
+      required: false
+    - label: You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
+      required: false
+- type: dropdown
+  id: version
+  attributes:
+    label: Version
+    description: Which version of the Kubeflow platform are you using?
+    options:
+    - master
+    - 1.9
+  validations:
+    required: true
+- type: textarea
+  id: description
+  attributes:
+    label: Detailed Description
+    placeholder: Provide a clear description of the issue and its impact.
+  validations:
+    required: true
+- type: textarea
+  id: steps
+  attributes:
+    label: Steps to Reproduce
+    placeholder: |
+      1. Describe the initial setup.
+      2. Detail the steps leading to the issue.
+  validations:
+    required: true
+- type: textarea
+  id: screenshots
+  attributes:
+    label: Screenshots or Videos (Optional)
+- type: markdown
+  attributes:
+    value: |
+      > **Note:** All required fields must be completed before submitting your report.
+
+      Thank you for your contribution.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+# Pull Request Template for Kubeflow Manifests
+
+## ✏️ Summary of Changes
+> Describe the changes you have made, including any refactoring or feature additions.
+
+## 📦 Dependencies
+> List any dependencies or related PRs (e.g., "Depends on #123").
+
+## 🐛 Related Issues
+> Link any issues that are resolved or affected by this PR.
+
+## ✅ Contributor Checklist
+  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
+  - [ ] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
+
+---     
+ 
+> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
+  

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,48 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '0 0 * * *' # Run every day at midnight
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 60
+        days-before-close: 21
+        # The message that will be added as a comment to the issues
+        # when the stale workflow marks it automatically as stale with a label.
+        stale-issue-message: >
+          This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.
+        # The message that will be added as a comment to the issues
+        # when the stale workflow closes it automatically after being stale for too long.
+        close-issue-message: >
+          This issue has been automatically closed because it has not had recent activity. Please comment "/reopen" to reopen it.
+        stale-issue-label: lifecycle/stale
+        # Exclude them from being marked as stale
+        exempt-issue-labels: lifecycle/frozen,enhancement,good first issue
+        # The message that will be added as a comment to the pull requests
+        # when the stale workflow marks it automatically as stale with a label.
+        stale-pr-message: "This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions. \n"
+        # The message that will be added as a comment to the pull requests
+        # when the stale workflow closes it automatically after being stale for too long.
+        close-pr-message: "This pull request has been automatically closed because it has not had recent  activity.You can reopen the PR if you want. \n"
+        stale-pr-label: lifecycle/stale
+        # Exclude them from being marked as stale
+        exempt-pr-labels: lifecycle/frozen,enhancement,good first issue
+        # The issues or the pull requests with a milestone will not be marked as stale automatically
+        exempt-all-milestones: true
+        # Learn more about operations: https://github.com/actions/stale#operations-per-run.
+        operations-per-run: 250

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# dashboard
+# Dashboard
+
+This repository is being migrated from kubeflow/kubeflow. Fell free to help us moving it according to the Option 3 in https://github.com/kubeflow/kubeflow/issues/7549.
+
+- We need to set up the new kubeflow/dashboard repository readme, owners file, and issue templates.
+- We should merge (or close) any obvious PRs for the dashboard components, and write down links for any we aren't ready for (so we don't loose track after migration)
+- The commit PR (#xxx) suffix in the new repository should be rewritten as (kubeflow/kubeflow#xxx) so we don't break the links
+- We should only move the folders under components/ that actually correspond to the new dashboard components (using git-filter-repo)
+- We should only migrate the necessary GitHub actions
+


### PR DESCRIPTION
kubeflow/dashboard

This repository is being migrated from kubeflow/kubeflow. Fell free to help us moving it according to the Option 3 in https://github.com/kubeflow/kubeflow/issues/7549.

- We need to set up the new kubeflow/dashboard repository readme, owners file, and issue templates.
- We should merge (or close) any obvious PRs for the dashboard components, and write down links for any we aren't ready for (so we don't loose track after migration)
- The commit PR (#xxx) suffix in the new repository should be rewritten as (kubeflow/kubeflow#xxx) so we don't break the links
- We should only move the folders under components/ that actually correspond to the new dashboard components (using git-filter-repo)
- We should only migrate the necessary GitHub actions

For "Central Components" (multi-user Kubeflow)
- [ ]     [access-management](https://github.com/kubeflow/kubeflow/tree/master/components/access-management) (KFAM, Auth)
- [ ]     [admission-webhook](https://github.com/kubeflow/kubeflow/tree/master/components/admission-webhook) (PodDefaults) (used by both Kubeflow Notebooks and Kubeflow Pipelines)
- [ ]     [centraldashboard](https://github.com/kubeflow/kubeflow/tree/master/components/centraldashboard)
- [ ]     [centraldashboard-angular](https://github.com/kubeflow/kubeflow/tree/master/components/centraldashboard-angular)
- [ ]     [profile-controller](https://github.com/kubeflow/kubeflow/tree/master/components/profile-controller)