### PR TITLE
chore: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to Kubeflow Dashboard
+
+Welcome to the Kubeflow Dashboard project!
+Contributions are welcome via GitHub pull requests.
+
+Please see the [Contributing to Kubeflow](https://www.kubeflow.org/docs/about/contributing/) page for more information.
+
+## Sign Your Work
+
+To certify you agree to the [Developer Certificate of Origin](https://developercertificate.org/) you must sign-off each commit message using `git commit --signoff`, or manually write the following:
+
+```text
+feat(ws): my commit message`
+
+Signed-off-by: John Smith <john-smith@users.noreply.github.com>
+```
+
+## Use Semantic Commits
+
+We use [semantic commits](https://www.conventionalcommits.org/en/v1.0.0/) to help us automatically generate changelogs and release notes.
+
+### Prefixes
+
+A semantic commit message must start with one of the following __prefixes__:
+
+- `fix:` (bug fixes)
+- `feat:` (new features)
+- `improve:` (improvements to existing features)
+- `refactor:` (code changes that neither fixes a bug nor adds a feature)
+- `revert:` (reverts a previous commit)
+- `test:` (adding missing tests, refactoring tests; no production code change)
+- `ci:` (changes to CI configuration or build scripts)
+- `docs:` (documentation only changes)
+- `chore:` (ignored in changelog)
+
+To indicate a breaking change, add `!` after the prefix, e.g. `feat!: my commit message`.
+
+### Scopes
+
+You may optionally include a __scope__ after the prefix, for example:
+
+- `dashboard` (changes to Central Dashboard)
+- `kfam` (changes to Kubeflow Access Management API)
+- `profile` (changes to _Kubeflow Profile Controller)
+
+### Examples
+
+Here are some examples of semantic commit messages:
+
+- `fix(dashboard): something that was broken`
+- `feat(dashboard): a new feature`
+- `improve: a general improvement`
+- `chore: update readme`

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Key features of Kubeflow Dashboard include:
    - _Note, authentication depends on how you [install](https://www.kubeflow.org/docs/started/installing-kubeflow/#kubeflow-platform) your Kubeflow Platform, and is not directly handled by Kubeflow Dashboard._
 - Ability to [Customize](https://www.kubeflow.org/docs/components/central-dash/customize/) and include links to third-party applications.
 
+## Components
+
 In this repository, there are multiple components which are versioned and released together:
 
 - `access-management` - Kubeflow Access Management
@@ -45,4 +47,4 @@ Connect with _other users_ and the [Notebooks Working Group](https://github.com/
 
 ## Contributing
 
-Please see the [Contributing to Kubeflow](https://www.kubeflow.org/docs/about/contributing/) page for more information.
+Please see the [`CONTRIBUTING.md`](CONTRIBUTING.md) file for more information.


### PR DESCRIPTION
This PR is a small follow up to https://github.com/kubeflow/dashboard/pull/75

It adds a `CONTRIBUTING.md` to the root of the repo.