### PR TITLE
docs(dashboard): updated centraldashboard-angular developer guidance

### DIFF
--- a/components/centraldashboard-angular/README.md
+++ b/components/centraldashboard-angular/README.md
@@ -15,7 +15,7 @@ wip-placeholder
 
 ### Getting Started
 
-Make sure you have and use the proper version of `node` installed along with `npm` for this component (See Dockerfile). First, clone the repository and change directories to `components/centraldashboard`
+Make sure you have and use the proper version of `node` installed along with `npm` for this component (See Dockerfile). First, clone the repository and change directories to `components/centraldashboard-angular`
 
 ### Backend
 
@@ -25,18 +25,41 @@ Backend server side code resides in the [backend](./backend) directory. The serv
 ```
 cd components/centraldashboard-angular/backend
 npm i
-npm run backend
+npm run build
+npm run serve
 ```
 
 This starts the Express API server at http://localhost:8082. Requests from the front-end starting with `/api` are proxied to the Express server. All other requests are handled by the front-end server which mirrors the production configuration.
 
+ℹ️ The server will also attempt to connect to the Kubernetes cluster as identified in `kubectl config current-context`
+
 ### Frontend
 
+With the re-organization of `kubeflow/dashboard` from `kubeflow/kubeflow` - the `frontend` component current still requires dependencies from `kubeflow-common-lib` package of `kubeflow/kubeflow` `crud-web-apps` component.
+
+In order to run `centraldashboard-angular` - one must build the `kubeflow-common-lib` library - which results in a `kubeflow` package being produced.  The `centraldashboard-angular` [`Makefile`](./Makefile) contains a `build-common-lib` target to handle this requirement.
+
+```bash
+cd components/centraldashboard-angular
+make build-common-lib
+```
+  - :warning: Ensure `node -v` aligns with the version of NodeJS as specified in the [`Dockerfile`](./Dockerfile).  Using later versions of NodeJS can cause the Angular build to hang.
+
+Once the `kubeflow-common-lib` is built and linked successfully, you should be able to verify via the following:
+```bash
+npm -g ls kubeflow
+[...]/.nvm/versions/node/v16.20.2/lib
+└── kubeflow@0.0.4 -> [...]/kubeflow-dashboard/components/centraldashboard-angular/kubeflow-common-lib/dist/kubeflow
+```
+
+Finally, the `frontend` component of `kubeflow/dashboard` can then be built and served using the following commands:
 ```bash
 cd components/centraldashboard-angular/frontend
 npm i
+npm link kubeflow
 npm run serve
 ```
+- :warning: Order of operations presented above is crucial.  As the `kubeflow` package is not listed in [`package.json`](./frontend/package.json), the `npm link kubeflow` command **must** be executed **after** `npm i`.
 
 This installs all dependencies and serves the frontend at http://localhost:4200.
 

--- a/components/centraldashboard-angular/frontend/.gitignore
+++ b/components/centraldashboard-angular/frontend/.gitignore
@@ -10,6 +10,7 @@
 
 # dependencies
 /node_modules
+/.angular
 
 # profiling files
 chrome-profiler-events*.json


### PR DESCRIPTION
Updates `centraldashboard-angular` `README.md` for better guidance following the split into `kubeflow/dashboard` from `kubeflow/kubeflow`. Makes use of the `build-common-lib` Makefile target introduced in https://github.com/kubeflow/dashboard/pull/92.

Also adds a `.gitignore` entry for `.angular` - as following the local development guidance results in an `.angular/cache` directory we don't want in source control.