### PR TITLE
ci: add `access-management` tests

### DIFF
--- a/.github/workflows/kfam_multi_arch_test.yaml
+++ b/.github/workflows/kfam_multi_arch_test.yaml
@@ -1,0 +1,36 @@
+name: KFAM Multi-Arch Build Test
+on:
+  pull_request:
+    paths:
+      - components/access-management/**
+      - releasing/version/VERSION
+    branches:
+      - main
+      - v*-branch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  IMG: ghcr.io/kubeflow/kubeflow/kfam
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build multi-arch Image
+      run: |
+        cd components/access-management
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch


### PR DESCRIPTION
Part of https://github.com/kubeflow/dashboard/issues/74

TODO: Add [.github/workflows/kfam_docker_publish.yaml](https://github.com/kubeflow/kubeflow/tree/master/.github/workflows/kfam_docker_publish.yaml) once we are ready for publish/release.