### PR TITLE
fix: Fix Istio sidecar injection by moving from annotations to labels

### DIFF
--- a/components/admission-webhook/manifests/base/deployment.yaml
+++ b/components/admission-webhook/manifests/base/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   template:
     metadata:
-      annotations:
+      labels:
         sidecar.istio.io/inject: "false"
     spec:
       containers:

--- a/components/centraldashboard/manifests/base/deployment.yaml
+++ b/components/centraldashboard/manifests/base/deployment.yaml
@@ -13,7 +13,6 @@ spec:
     metadata:
       labels:
         app: centraldashboard
-      annotations:
         sidecar.istio.io/inject: "true"
     spec:
       containers:

--- a/components/profile-controller/config/manager/manager.yaml
+++ b/components/profile-controller/config/manager/manager.yaml
@@ -13,7 +13,7 @@ spec:
   replicas: 1
   template:
     metadata:
-      annotations:
+      labels:
         sidecar.istio.io/inject: "false"
     spec:
       containers:

--- a/components/profile-controller/config/overlays/kubeflow/patches/kfam.yaml
+++ b/components/profile-controller/config/overlays/kubeflow/patches/kfam.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   template:
     metadata:
-      annotations:
+      lavels:
         sidecar.istio.io/inject: "true"
     spec:
       securityContext:

--- a/components/profile-controller/config/overlays/kubeflow/patches/kfam.yaml
+++ b/components/profile-controller/config/overlays/kubeflow/patches/kfam.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   template:
     metadata:
-      lavels:
+      labels:
         sidecar.istio.io/inject: "true"
     spec:
       securityContext:


### PR DESCRIPTION
## Description
This PR fixes Istio sidecar injection configuration in the Model Registry component by replacing deprecated annotations with the recommended labels approach. According to Istio documentation, controlling sidecar injection via annotations is no longer the preferred method.

## Issues and Related PR
Issue: https://github.com/kubeflow/manifests/issues/2798
Part of PR: https://github.com/kubeflow/manifests/pull/3044