### PR TITLE
fix: Fix Kustomize v5 warnings

### DIFF
--- a/components/admission-webhook/manifests/base/kustomization.yaml
+++ b/components/admission-webhook/manifests/base/kustomization.yaml
@@ -8,11 +8,6 @@ resources:
 - service-account.yaml
 - service.yaml
 - crd.yaml
-commonLabels:
-  app: poddefaults
-  kustomize.component: poddefaults
-  app.kubernetes.io/component: poddefaults
-  app.kubernetes.io/name: poddefaults
 images:
 - name: ghcr.io/kubeflow/kubeflow/poddefaults-webhook
   newName: ghcr.io/kubeflow/kubeflow/poddefaults-webhook
@@ -20,33 +15,61 @@ images:
 namespace: kubeflow
 generatorOptions:
   disableNameSuffixHash: true
-vars:
+configurations:
+- params.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: poddefaults
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+    kustomize.component: poddefaults
+replacements:
 # These vars are used to substitute in the namespace, service name and
 # deployment name into the mutating WebHookConfiguration.
 # Since its a CR kustomize isn't aware of those fields and won't
 # transform them.
 # We need the var names to be relatively unique so that when we
 # compose with other applications they won't conflict.
-- fieldref:
+- source:
     fieldPath: metadata.namespace
-  name: podDefaultsNamespace
-  objref:
-    apiVersion: v1
     kind: Service
     name: service
-- fieldref:
+    version: v1
+  targets:
+  - fieldPaths:
+    - webhooks.0.clientConfig.service.namespace
+    select:
+      group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      name: mutating-webhook-configuration
+      version: v1
+- source:
     fieldPath: metadata.name
-  name: podDefaultsServiceName
-  objref:
-    apiVersion: v1
     kind: Service
     name: service
-- fieldref:
+    version: v1
+  targets:
+  - fieldPaths:
+    - webhooks.0.clientConfig.service.name
+    select:
+      group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      name: mutating-webhook-configuration
+      version: v1
+- source:
     fieldPath: metadata.name
-  name: podDefaultsDeploymentName
-  objref:
-    apiVersion: apps/v1
+    group: apps
     kind: Deployment
     name: deployment
-configurations:
-- params.yaml
+    version: v1
+  targets:
+  - fieldPaths:
+    - webhooks.0.name
+    options:
+      delimiter: .
+    select:
+      group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      name: mutating-webhook-configuration
+      version: v1

--- a/components/admission-webhook/manifests/base/mutating-webhook-configuration.yaml
+++ b/components/admission-webhook/manifests/base/mutating-webhook-configuration.yaml
@@ -13,7 +13,7 @@ webhooks:
       path: /apply-poddefault
   sideEffects: None
   failurePolicy: Fail
-  name: $(podDefaultsDeploymentName).kubeflow.org
+  name: podDefaultsDeploymentName_PLACEHOLDER.kubeflow.org
   namespaceSelector:
     matchLabels:
       app.kubernetes.io/part-of: kubeflow-profile

--- a/components/centraldashboard-angular/manifests/base/configmap.yaml
+++ b/components/centraldashboard-angular/manifests/base/configmap.yaml
@@ -1,4 +1,7 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: centraldashboard-angular-config
 data:
   settings: |-
     {
@@ -130,6 +133,3 @@ data:
           }
         ]
     }
-kind: ConfigMap
-metadata:
-  name: centraldashboard-angular-config

--- a/components/centraldashboard-angular/manifests/base/deployment.yaml
+++ b/components/centraldashboard-angular/manifests/base/deployment.yaml
@@ -31,13 +31,13 @@ spec:
           protocol: TCP
         env:
         - name: USERID_HEADER
-          value: $(CD_USERID_HEADER)
+          value: CD_USERID_HEADER_PLACEHOLDER
         - name: USERID_PREFIX
-          value: $(CD_USERID_PREFIX)
+          value: CD_USERID_PREFIX_PLACEHOLDER
         - name: PROFILES_KFAM_SERVICE_HOST
           value: profiles-kfam.kubeflow
         - name: REGISTRATION_FLOW
-          value: $(CD_REGISTRATION_FLOW)
+          value: CD_REGISTRATION_FLOW_PLACEHOLDER
         - name: DASHBOARD_CONFIGMAP
-          value: $(CD_CONFIGMAP_NAME)
+          value: CD_CONFIGMAP_NAME_PLACEHOLDER
       serviceAccountName: centraldashboard-angular

--- a/components/centraldashboard-angular/manifests/base/kustomization.yaml
+++ b/components/centraldashboard-angular/manifests/base/kustomization.yaml
@@ -10,11 +10,6 @@ resources:
 - service-account.yaml
 - service.yaml
 - configmap.yaml
-commonLabels:
-  kustomize.component: centraldashboard-angular
-  app: centraldashboard-angular
-  app.kubernetes.io/component: centraldashboard-angular
-  app.kubernetes.io/name: centraldashboard-angular
 images:
 - name: ghcr.io/kubeflow/kubeflow/centraldashboard-angular
   newName: ghcr.io/kubeflow/kubeflow/centraldashboard-angular
@@ -25,46 +20,63 @@ configMapGenerator:
   name: centraldashboard-angular-parameters
 generatorOptions:
   disableNameSuffixHash: true
-vars:
-- fieldref:
-    fieldPath: metadata.namespace
-  name: CD_NAMESPACE
-  objref:
-    apiVersion: v1
-    kind: Service
-    name: centraldashboard-angular
-- fieldref:
-    fieldPath: data.CD_CLUSTER_DOMAIN
-  name: CD_CLUSTER_DOMAIN
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: centraldashboard-angular-parameters
-- fieldref:
+labels:
+- includeSelectors: true
+  pairs:
+    app: centraldashboard-angular
+    app.kubernetes.io/component: centraldashboard-angular
+    app.kubernetes.io/name: centraldashboard-angular
+    kustomize.component: centraldashboard-angular
+replacements:
+- source:
     fieldPath: data.CD_USERID_HEADER
-  name: CD_USERID_HEADER
-  objref:
-    apiVersion: v1
     kind: ConfigMap
     name: centraldashboard-angular-parameters
-- fieldref:
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.[name=centraldashboard-angular].env.[name=USERID_HEADER].value
+    select:
+      group: apps
+      kind: Deployment
+      name: centraldashboard-angular
+      version: v1
+- source:
     fieldPath: data.CD_USERID_PREFIX
-  name: CD_USERID_PREFIX
-  objref:
-    apiVersion: v1
     kind: ConfigMap
     name: centraldashboard-angular-parameters
-- fieldref:
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.[name=centraldashboard-angular].env.[name=USERID_PREFIX].value
+    select:
+      group: apps
+      kind: Deployment
+      name: centraldashboard-angular
+      version: v1
+- source:
     fieldPath: data.CD_REGISTRATION_FLOW
-  name: CD_REGISTRATION_FLOW
-  objref:
-    apiVersion: v1
     kind: ConfigMap
     name: centraldashboard-angular-parameters
-- fieldref:
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.[name=centraldashboard-angular].env.[name=REGISTRATION_FLOW].value
+    select:
+      group: apps
+      kind: Deployment
+      name: centraldashboard-angular
+      version: v1
+- source:
     fieldPath: metadata.name
-  name: CD_CONFIGMAP_NAME
-  objref:
-    apiVersion: v1
     kind: ConfigMap
     name: centraldashboard-angular-config
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.[name=centraldashboard-angular].env.[name=DASHBOARD_CONFIGMAP].value
+    select:
+      group: apps
+      kind: Deployment
+      name: centraldashboard-angular
+      version: v1

--- a/components/centraldashboard-angular/manifests/overlays/istio/kustomization.yaml
+++ b/components/centraldashboard-angular/manifests/overlays/istio/kustomization.yaml
@@ -8,11 +8,12 @@ resources:
 
 namespace: kubeflow
 
-commonLabels:
-  kustomize.component: centraldashboard-angular
-  app: centraldashboard-angular
-  app.kubernetes.io/component: centraldashboard-angular
-  app.kubernetes.io/name: centraldashboard-angular
-
 configurations:
 - params.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: centraldashboard-angular
+    app.kubernetes.io/component: centraldashboard-angular
+    app.kubernetes.io/name: centraldashboard-angular
+    kustomize.component: centraldashboard-angular

--- a/components/centraldashboard-angular/manifests/overlays/kserve/kustomization.yaml
+++ b/components/centraldashboard-angular/manifests/overlays/kserve/kustomization.yaml
@@ -4,11 +4,13 @@ kind: Kustomization
 resources:
 - ../istio
 
-commonLabels:
-  kustomize.component: centraldashboard-angular
-  app: centraldashboard-angular
-  app.kubernetes.io/component: centraldashboard-angular
-  app.kubernetes.io/name: centraldashboard-angular
 
-patchesStrategicMerge:
-- patches/configmap.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: centraldashboard-angular
+    app.kubernetes.io/component: centraldashboard-angular
+    app.kubernetes.io/name: centraldashboard-angular
+    kustomize.component: centraldashboard-angular
+patches:
+- path: patches/configmap.yaml


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
Part of https://github.com/kubeflow/manifests/issues/2991

Fixes some of the warnings, when applying the manifests for:
* admission-webhook 
* centraldashboard-angular

For Profile-controller, not sure that the manifests are valid. 
https://github.com/kubeflow/dashboard/blob/main/components/profile-controller/config/base/kustomization.yaml#L1