### PR TITLE
feat(kfam): support multiple cluster admin

### DIFF
--- a/components/access-management/kfam/api_default.go
+++ b/components/access-management/kfam/api_default.go
@@ -45,12 +45,12 @@ type KfamV1Alpha1Interface interface {
 type KfamV1Alpha1Client struct {
 	profileClient ProfileInterface
 	bindingClient BindingInterface
-	clusterAdmin  []string
+	clusterAdmins []string
 	userIdHeader  string
 	userIdPrefix  string
 }
 
-func NewKfamClient(userIdHeader string, userIdPrefix string, clusterAdmin string) (*KfamV1Alpha1Client, error) {
+func NewKfamClient(userIdHeader string, userIdPrefix string, clusterAdmins []string) (*KfamV1Alpha1Client, error) {
 	profileRESTClient, err := getRESTClient(profileRegister.GroupName, profileRegister.GroupVersion)
 	if err != nil {
 		return nil, err
@@ -83,9 +83,9 @@ func NewKfamClient(userIdHeader string, userIdPrefix string, clusterAdmin string
 			kubeClient:        kubeClient,
 			roleBindingLister: roleBindingLister,
 		},
-		clusterAdmin: []string{clusterAdmin},
-		userIdHeader: userIdHeader,
-		userIdPrefix: userIdPrefix,
+		clusterAdmins: clusterAdmins,
+		userIdHeader:  userIdHeader,
+		userIdPrefix:  userIdPrefix,
 	}, nil
 }
 
@@ -291,7 +291,7 @@ func (c *KfamV1Alpha1Client) getUserEmail(header http.Header) string {
 }
 
 func (c *KfamV1Alpha1Client) isClusterAdmin(queryUser string) bool {
-	for _, val := range c.clusterAdmin {
+	for _, val := range c.clusterAdmins {
 		if val == queryUser {
 			return true
 		}
@@ -299,7 +299,7 @@ func (c *KfamV1Alpha1Client) isClusterAdmin(queryUser string) bool {
 	return false
 }
 
-//isOwnerOrAdmin return true if queryUser is cluster admin or profile owner
+// isOwnerOrAdmin return true if queryUser is cluster admin or profile owner
 func (c *KfamV1Alpha1Client) isOwnerOrAdmin(queryUser string, profileName string) bool {
 	isAdmin := c.isClusterAdmin(queryUser)
 	prof, err := c.profileClient.Get(profileName, metav1.GetOptions{})

--- a/components/access-management/main.go
+++ b/components/access-management/main.go
@@ -13,6 +13,7 @@ package main
 import (
 	"flag"
 	"net/http"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -37,16 +38,16 @@ func main() {
 	log.Printf("Server started")
 	var userIdHeader string
 	var userIdPrefix string
-	var clusterAdmin string
+	var clusterAdmins string
 	flag.StringVar(&userIdHeader, USERIDHEADER, "x-goog-authenticated-user-email", "Key of request header containing user id")
 	flag.StringVar(&userIdPrefix, USERIDPREFIX, "accounts.google.com:", "Request header user id common prefix")
-	flag.StringVar(&clusterAdmin, CLUSTERADMIN, "", "cluster admin")
+	flag.StringVar(&clusterAdmins, CLUSTERADMIN, "", "cluster admin")
 	flag.Parse()
 
 	profile.AddToScheme(scheme.Scheme)
 	istioSecurityClient.AddToScheme(scheme.Scheme)
 
-	profileClient, err := kfam.NewKfamClient(userIdHeader, userIdPrefix, clusterAdmin)
+	profileClient, err := kfam.NewKfamClient(userIdHeader, userIdPrefix, strings.Split(clusterAdmins, ","))
 	if err != nil {
 		log.Print(err)
 		panic(err)


### PR DESCRIPTION
<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

This PR enables support for multiple cluster admins.

```shell
/access-management -cluster-admin "<userA>,<userB>"
```

Originally, this was implemented in https://github.com/kubeflow/kubeflow/pull/7267, but since the kfam codebase has been moved here, I'm reopening the PR in this repository.