### PR TITLE
ci: Migrate kubeflow/kubeflow poddefaults_oci_publish.yaml GitHub Action to kubeflow/dashboard

### DIFF
--- a/.github/workflows/poddefaults_oci_publish.yaml
+++ b/.github/workflows/poddefaults_oci_publish.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - components/admission-webhook/**
       - releasing/version/VERSION
+      - .github/workflows/poddefaults_oci_publish.yaml
 
 env:
   IMG: ghcr.io/kubeflow/kubeflow/poddefaults-webhook


### PR DESCRIPTION
 related: #74 

My Dockerhub:
https://hub.docker.com/repository/docker/liavweiss/kubeflow-dashboard-lweiss-fork/tags
![image](https://github.com/user-attachments/assets/d4489e86-53a0-4d44-b860-ca08e8bbeec1)

 
The successful job:
https://github.com/liavweiss/dashboard/actions/runs/16026784047/job/45216630561
![image](https://github.com/user-attachments/assets/4f30fb34-3c00-43b9-bcd3-614b2a63dbac)
