### PR TITLE
fix: Remove redundant chmod step from workflows 

### DIFF
--- a/.github/workflows/central_dashboard_angular_integration_test.yaml
+++ b/.github/workflows/central_dashboard_angular_integration_test.yaml
@@ -41,9 +41,6 @@ jobs:
     - name: Create Kubeflow Namespace
       run: kubectl create namespace kubeflow
 
-    - name: Make Scripts Executable
-      run: chmod +x testing/gh-actions/*.sh
-
     - name: Deploy CentralDashboard-Angular Component
       run: |
         cd components/centraldashboard-angular

--- a/.github/workflows/central_dashboard_integration_test.yaml
+++ b/.github/workflows/central_dashboard_integration_test.yaml
@@ -44,9 +44,6 @@ jobs:
     - name: Create Kubeflow Namespace
       run: kubectl create namespace kubeflow
 
-    - name: Make Scripts Executable
-      run: chmod +x testing/gh-actions/*.sh
-
     - name: Install Profile Controller (prerequisite)
       run: |
         cd components/profile-controller

--- a/.github/workflows/end_to_end_integration_test.yaml
+++ b/.github/workflows/end_to_end_integration_test.yaml
@@ -53,9 +53,6 @@ jobs:
     - name: Create Kubeflow Namespace
       run: kubectl create namespace kubeflow
 
-    - name: Make Scripts Executable
-      run: chmod +x testing/gh-actions/*.sh
-
     - name: Deploy Profile Controller Component
       run: |
         ./testing/gh-actions/deploy_component.sh \

--- a/.github/workflows/poddefaults_intergration_test.yaml
+++ b/.github/workflows/poddefaults_intergration_test.yaml
@@ -47,9 +47,6 @@ jobs:
     - name: Create Kubeflow Namespace
       run: kubectl create namespace kubeflow
 
-    - name: Make Scripts Executable
-      run: chmod +x testing/gh-actions/*.sh
-
     - name: Deploy PodDefaults Webhook Component
       run: |
         ./testing/gh-actions/deploy_component.sh \

--- a/.github/workflows/profiles_kfam_integration_test.yaml
+++ b/.github/workflows/profiles_kfam_integration_test.yaml
@@ -46,9 +46,6 @@ jobs:
     - name: Create Kubeflow Namespace
       run: kubectl create namespace kubeflow
 
-    - name: Make Scripts Executable
-      run: chmod +x testing/gh-actions/*.sh
-
     - name: Deploy Profile Controller Component
       run: |
         ./testing/gh-actions/deploy_component.sh \


### PR DESCRIPTION
This PR solve issue #120 

Remove redundant chmod step from workflows - scripts already have executable permissions