### PR TITLE
ci: permissions to allow publish of profile-controller package

### DIFF
--- a/.github/workflows/profile_controller_oci_publish.yaml
+++ b/.github/workflows/profile_controller_oci_publish.yaml
@@ -12,6 +12,10 @@ env:
   IMG: ghcr.io/kubeflow/dashboard/profile-controller
   ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   push_to_registry:
     name: Build & Push OCI image to GHCR
@@ -63,4 +67,4 @@ jobs:
         run: |
           export TAG=$(cat releasing/version/VERSION)
           cd components/profile-controller
-          make docker-build-push-multi-arch 
+          make docker-build-push-multi-arch


### PR DESCRIPTION
With the recent merge of https://github.com/kubeflow/dashboard/pull/115 to start publishing packages from `kubeflow/dashboard` - all workflows were able to succeed with the exception of `profile-controller`.

Based on some experiments in my personal organization - I believe we can resolve this failing workflow with 2 additional changes:
1. We need to change the `Package Settings` of `profile-controller` to ensure `kubeflow/dashboard` repo has (at minimum) `Write` acccess
    - :warning: I do not have permissions to check and/or implement this change - so will need help from someone in the community!
2. We need to explicitly specify the `permissions` block in the `_publish` workflow for `profile-controller`
    - :information_source: That is the goal of this PR

This GHA run on my personal organization demonstrates that with the above 2 changes - I was able to update an existing package _from a different repository_
- https://github.com/andyatmiami/test-repo-2/actions/runs/17739059966/job/50408184751
