### PR TITLE
ci: disallow semantic commit scopes in PR titles

### DIFF
--- a/.github/workflows/semantic-prs.yaml
+++ b/.github/workflows/semantic-prs.yaml
@@ -17,7 +17,7 @@ jobs:
     name: Validate Title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.5.3
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Since we now have the appropriate labels in GitHub we can disallow scopes entirely for the PR titles.

Follow up to https://github.com/kubeflow/dashboard/pull/192

---

Applying this change requires the titles of the following PRs to be changed:
- [x] https://github.com/kubeflow/dashboard/pull/199
- [x] https://github.com/kubeflow/dashboard/pull/198
- [x] https://github.com/kubeflow/dashboard/pull/190

```
$ gh pr list --json title | jq -r ".[].title" | grep -v deps | grep -E "\):" 
refactor(profile): extract istio resources into component
refactor(dashboard): update kustomize manifests of poddefaults webhooks structure as per notebooks v2
fix(dashboard): make buttons look clickable
```

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->