### PR TITLE
chore: Add planning templates to `kubeflow/dashboard`

### DIFF
--- a/.github/ISSUE_TEMPLATE/planning_epic.yml
+++ b/.github/ISSUE_TEMPLATE/planning_epic.yml
@@ -1,0 +1,27 @@
+name: "[Planning] Epic"
+description: "🛑 Only intended to be used by Kubeflow project managers"
+title: "[EPIC] <short description>"
+labels:
+  - "kind/plan-epic"
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to create an epic!
+  - type: checkboxes
+    id: certification
+    attributes:
+      label: Certification
+      description: Please confirm your role
+      options:
+        - label: I certify I am an Epic Owner for Kubeflow Notebooks 2.0 and expected to create planning-related issues.
+          required: true
+  - type: textarea
+    id: user-story
+    attributes:
+      label: User Story
+      description: Describe the feature from the end user's perspective, including who they are, what they want to achieve, and why it's important.
+      placeholder: As a [type of user], I want [goal] so that [benefit]
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/planning_feature.yml
+++ b/.github/ISSUE_TEMPLATE/planning_feature.yml
@@ -1,0 +1,48 @@
+name: "[Planning] Feature"
+description: "🛑 Only intended to be used by Kubeflow project managers"
+title: "[FEATURE] <short description>"
+labels:
+  - "kind/plan-feature"
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to create a feature request!
+  - type: checkboxes
+    id: certification
+    attributes:
+      label: Certification
+      description: Please confirm your role
+      options:
+        - label: I certify I am an Epic Owner for Kubeflow Notebooks 2.0 and expected to create planning-related issues.
+          required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Explain the reasoning behind this feature. What problem does it solve or what value does it add?
+      placeholder: This feature will help users by...
+    validations:
+      required: true
+  - type: textarea
+    id: design
+    attributes:
+      label: High Level Design / Mock-ups
+      description: Provide a top-level overview of the proposed solution. Include diagrams, rough mockups, or architectural notes if helpful.
+      placeholder: |
+        [Add your design details here]
+        - Consider including diagrams
+        - Add mockups if available
+        - Describe the architecture
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Define what needs to be true for this feature to be considered complete. Be as clear and measurable as possible.
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+        - [ ] Criterion 3
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/planning_task.yml
+++ b/.github/ISSUE_TEMPLATE/planning_task.yml
@@ -1,0 +1,38 @@
+name: "[Planning] Task"
+description: "🛑 Only intended to be used by Kubeflow project managers"
+title: "[TASK] <short description>"
+labels:
+  - "kind/plan-task"
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to create a task!
+  - type: checkboxes
+    id: certification
+    attributes:
+      label: Certification
+      description: Please confirm your role
+      options:
+        - label: I certify I am an Epic Owner for Kubeflow Notebooks 2.0 and expected to create planning-related issues.
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a brief explanation of what this task involves and why it's needed. Focus on the scope and intent of the work.
+      placeholder: This task will...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List the specific, measurable conditions that must be met for the task to be considered complete.
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+        - [ ] Criterion 3
+    validations:
+      required: true


### PR DESCRIPTION
Those have already been quite established in `kubeflow/notebooks` so they will most also prove to be useful for this repository.

Link: https://github.com/kubeflow/notebooks/pull/361

---

Still marking as a Draft until the following labels have been created:
- `kind/plan-epic`
- `kind/plan-feature`
- `kind/plan-task`