### PR TITLE
fix(dashboard): upgrade VirtualService manifests to v1

### DIFF
--- a/components/centraldashboard-angular/manifests/kustomize/components/istio/virtual-service.yaml
+++ b/components/centraldashboard-angular/manifests/kustomize/components/istio/virtual-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: dashboard-angular

--- a/components/centraldashboard/manifests/kustomize/components/istio/virtual-service.yaml
+++ b/components/centraldashboard/manifests/kustomize/components/istio/virtual-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: dashboard

--- a/components/profile-controller/config/overlays/kubeflow/virtual-service.yaml
+++ b/components/profile-controller/config/overlays/kubeflow/virtual-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: profiles-kfam


### PR DESCRIPTION
Fixes #201

### Motivation
The `VirtualService` manifests were using the deprecated `v1alpha3` API. This PR upgrades them to the stable `networking.istio.io/v1` API as requested.

### Changes
- Updated `apiVersion` from `networking.istio.io/v1alpha3` to `networking.istio.io/v1` in:
  - `components/centraldashboard-angular/manifests/kustomize/components/istio/virtual-service.yaml`
  - `components/profile-controller/config/overlays/kubeflow/virtual-service.yaml`
  - `components/centraldashboard/manifests/kustomize/components/istio/virtual-service.yaml`