### PR TITLE
fix: upgrade VirtualService manifests to v1

### DIFF
--- a/components/centraldashboard-angular/manifests/kustomize/components/istio/virtual-service.yaml
+++ b/components/centraldashboard-angular/manifests/kustomize/components/istio/virtual-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: dashboard-angular

--- a/components/centraldashboard/manifests/kustomize/components/istio/virtual-service.yaml
+++ b/components/centraldashboard/manifests/kustomize/components/istio/virtual-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: dashboard

--- a/components/profile-controller/config/overlays/kubeflow/virtual-service.yaml
+++ b/components/profile-controller/config/overlays/kubeflow/virtual-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: profiles-kfam


### PR DESCRIPTION
closes: #201

### Motivation
Upgrading deprecated Istio `v1alpha3` APIs to the stable `v1` version.

### Changes
- Updated `apiVersion` to `networking.istio.io/v1` in centraldashboard, centraldashboard-angular, and profile-controller manifests.