### PR TITLE
fix: upgrade VirtualService manifests from v1alpha3 to v1

### DIFF
--- a/components/centraldashboard-angular/manifests/kustomize/components/istio/virtual-service.yaml
+++ b/components/centraldashboard-angular/manifests/kustomize/components/istio/virtual-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: dashboard-angular

--- a/components/centraldashboard/manifests/kustomize/components/istio/virtual-service.yaml
+++ b/components/centraldashboard/manifests/kustomize/components/istio/virtual-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: dashboard

--- a/components/profile-controller/config/overlays/kubeflow/virtual-service.yaml
+++ b/components/profile-controller/config/overlays/kubeflow/virtual-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: profiles-kfam


### PR DESCRIPTION
## Description

Upgrades VirtualService API version from the deprecated `networking.istio.io/v1alpha3` to stable `networking.istio.io/v1` across all dashboard manifests.

**Changes:**
- `components/centraldashboard/manifests/kustomize/components/istio/virtual-service.yaml`
- `components/centraldashboard-angular/manifests/kustomize/components/istio/virtual-service.yaml`  
- `components/profile-controller/config/overlays/kubeflow/virtual-service.yaml`

No spec changes required - v1 API is backward compatible with existing VirtualService configurations.

## Related Issue
Closes #201

## Verification
- All 3 files updated with correct `apiVersion: networking.istio.io/v1`
-  YAML syntax preserved 
-  No functional changes to routing/gateway configuration