### PR TITLE
fix: handle azure platform in metrics service factory

### DIFF
--- a/components/centraldashboard/app/metrics_service_factory.ts
+++ b/components/centraldashboard/app/metrics_service_factory.ts
@@ -23,6 +23,9 @@ export async function getMetricsService(k8sService: KubernetesService):
         const projectId = platformInfo.provider.split('/')[2];
         return new StackdriverMetricsService(
             new MetricServiceClient(), projectId, nodeNames);
+      case 'azure':
+        console.info('"azure" platform detected. Metrics disabled (use Prometheus for AKS).');
+        return null;    
       default:
         console.warn(`"${
             platformInfo

--- a/components/centraldashboard/app/metrics_service_factory_test.ts
+++ b/components/centraldashboard/app/metrics_service_factory_test.ts
@@ -76,4 +76,30 @@ describe('Metrics Service Factory getMetricsService', () => {
 
     expect(await getMetricsService(mockK8sService)).toBe(null);
   });
+
+  it('Returns null for azure platform without a console.warn', async () => {
+    const nodes = [{
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {name: 'aks-node-1'},
+      spec: {
+        podCIDR: '10.244.0.0/24',
+        providerID:
+            'azure:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/aks-node-1'
+      },
+    }] as k8s.V1Node[];
+    mockK8sService.getNodes.and.returnValue(Promise.resolve(nodes));
+    mockK8sService.getPlatformInfo.and.returnValue(Promise.resolve({
+      provider:
+          'azure:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/aks-node-1',
+      providerName: 'azure',
+      kubeflowVersion: '1.0.0'
+    }));
+
+    const warnSpy = spyOn(console, 'warn');
+    const metricsService = await getMetricsService(mockK8sService);
+
+    expect(metricsService).toBe(null);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Closes #194 

Fix
Added an explicit case 'azure': branch that:

Logs a clear console.info (not warn) explaining that metrics are intentionally disabled on Azure and directs users to Prometheus as the appropriate alternative
Returns null explicitly, making the intent clear rather than falling through

```
case 'azure':
  console.info('"azure" platform detected. Metrics disabled (use Prometheus for AKS).');
  return null;
```

### Test
Added a regression test to `metrics_service_factory_test.ts` that:
- Simulates an AKS cluster with a real Azure `providerID` format
- Asserts `getMetricsService()` returns `null`
- Asserts `console.warn` is **never called** — this is the critical guard that would catch any future regression back to the old behaviour

<img width="848" height="275" alt="image" src="https://github.com/user-attachments/assets/d6e57a53-d230-461c-8e0f-661eff4cf2d9" />
