### PR TITLE
fix: add missing seccomp profile in kfam container

### DIFF
--- a/components/profile-controller/manifests/kustomize/components/kfam/manager_kfam_patch.yaml
+++ b/components/profile-controller/manifests/kustomize/components/kfam/manager_kfam_patch.yaml
@@ -42,6 +42,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
This led to us having an unhealthy KFAM deployment due to the PSS level enforced in `kubeflow/manifests`.

Signed-off-by: Christian Heusel <christian@heusel.eu>

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
