### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+
+  # Disabled until we're in a state where we can actually take care of the
+  # updates proposed by dependabot
+  #
+  # - package-ecosystem: "gomod"
+  #   open-pull-requests-limit: 5
+  #   cooldown:
+  #     default-days: 7
+  #   directories:
+  #     - "/components/access-management"
+  #     - "/components/poddefaults-webhooks"
+  #     - "/components/profile-controller"
+  #   schedule:
+  #     interval: "daily"
+  #   commit-message:
+  #     prefix: "chore"


### PR DESCRIPTION
Add a dependabot configuration with the goal of reducing the signal-to-noise ratio for project maintainers/reviewers.
Currently we have a lot of pending PRs which we do not intend to merge, hence we should only re-introduce those bit by bit as we get ready on a per-ecosystem basis.

Additionally the frontend libraries can mostly not be upgraded due to the dependency on the abandoned `@polymer/polymer` (https://polymer-library.polymer-project.org/3.0/docs/devguide/feature-overview) library.
