### PR TITLE
fix: resolve iframe synchronization timing issue between load and click events

### DIFF
--- a/components/centraldashboard/public/components/iframe-container.js
+++ b/components/centraldashboard/public/components/iframe-container.js
@@ -54,7 +54,11 @@ export class IframeContainer extends PolymerElement {
         // Adds a click handler to be able to capture navigation events from
         // the captured iframe and set the page property which notifies
         const iframe = this.$.iframe;
-        iframe.addEventListener('load', () => {
+        iframe.addEventListener('load', (event) => {
+            const nextLocation = event.target.contentWindow.location;
+            const nextIframePage = nextLocation.href.slice(
+                nextLocation.origin.length);
+            this.page = nextIframePage;
             const syncIframePage = () => {
                 const iframeLocation = iframe.contentWindow.location;
                 const newIframePage = iframeLocation.href.slice(

--- a/components/centraldashboard/public/components/iframe-container.js
+++ b/components/centraldashboard/public/components/iframe-container.js
@@ -54,11 +54,7 @@ export class IframeContainer extends PolymerElement {
         // Adds a click handler to be able to capture navigation events from
         // the captured iframe and set the page property which notifies
         const iframe = this.$.iframe;
-        iframe.addEventListener('load', (event) => {
-            const nextLocation = event.target.contentWindow.location;
-            const nextIframePage = nextLocation.href.slice(
-                nextLocation.origin.length);
-            this.page = nextIframePage;
+        iframe.addEventListener('load', () => {
             const syncIframePage = () => {
                 const iframeLocation = iframe.contentWindow.location;
                 const newIframePage = iframeLocation.href.slice(
@@ -67,6 +63,16 @@ export class IframeContainer extends PolymerElement {
                     this.page = newIframePage;
                 }
             };
+            // Synchronize the page property on load so that server-side
+            // navigations are captured before any click or hashchange event.
+            // Non-HTTP(S) documents such as about:blank are skipped: their
+            // opaque origin serializes to "null", which would produce an
+            // invalid page value and corrupt the parent URL through the
+            // two-way page binding.
+            const {protocol} = iframe.contentWindow.location;
+            if (protocol === 'http:' || protocol === 'https:') {
+                syncIframePage();
+            }
             const {contentDocument} = iframe;
             contentDocument.addEventListener('click', syncIframePage);
             contentDocument.addEventListener('hashchange', syncIframePage);

--- a/components/centraldashboard/public/components/iframe-container_test.js
+++ b/components/centraldashboard/public/components/iframe-container_test.js
@@ -74,6 +74,7 @@ describe('Iframe Container', () => {
         };
         spyOnProperty(iframeContainer.$.iframe, 'contentWindow').and
             .returnValue({location: fakeLocation});
+        expect(iframeContainer.page).toBe(undefined);
         iframeContainer.$.iframe.contentDocument.firstChild.click();
         expect(iframeContainer.page).toBe('/foo/bar?name=blah');
     });
@@ -85,10 +86,43 @@ describe('Iframe Container', () => {
         };
         spyOnProperty(iframeContainer.$.iframe, 'contentWindow').and
             .returnValue({location: fakeLocation});
+        expect(iframeContainer.page).toBe(undefined);
         fakeLocation.href = 'http://testsite.com/foo/bar?name=blah#new-hash';
         iframeContainer.$.iframe.contentDocument
             .dispatchEvent(new Event('hashchange'));
         expect(iframeContainer.page).toBe('/foo/bar?name=blah#new-hash');
+    });
+
+    it('Should synchronize page property when an HTTP page loads',
+        async () => {
+            const fakeContentWindow = {
+                location: {
+                    href: 'http://testsite.com/foo/bar?name=blah',
+                    origin: 'http://testsite.com',
+                    protocol: 'http:',
+                },
+                postMessage: () => {},
+            };
+            spyOnProperty(iframeContainer.$.iframe, 'contentWindow').and
+                .returnValue(fakeContentWindow);
+            iframeContainer.$.iframe.dispatchEvent(new Event('load'));
+            expect(iframeContainer.page).toBe('/foo/bar?name=blah');
+        });
+
+    it('Should not synchronize page property when a non-HTTP(S) document ' +
+        'loads', async () => {
+        const fakeContentWindow = {
+            location: {
+                href: 'about:blank',
+                origin: 'null',
+                protocol: 'about:',
+            },
+            postMessage: () => {},
+        };
+        spyOnProperty(iframeContainer.$.iframe, 'contentWindow').and
+            .returnValue(fakeContentWindow);
+        iframeContainer.$.iframe.dispatchEvent(new Event('load'));
+        expect(iframeContainer.page).toBe(undefined);
     });
 
     it('Should send messages to iframed page', async () => {

--- a/components/centraldashboard/public/components/iframe-container_test.js
+++ b/components/centraldashboard/public/components/iframe-container_test.js
@@ -74,7 +74,6 @@ describe('Iframe Container', () => {
         };
         spyOnProperty(iframeContainer.$.iframe, 'contentWindow').and
             .returnValue({location: fakeLocation});
-        expect(iframeContainer.page).toBe(undefined);
         iframeContainer.$.iframe.contentDocument.firstChild.click();
         expect(iframeContainer.page).toBe('/foo/bar?name=blah');
     });
@@ -86,7 +85,6 @@ describe('Iframe Container', () => {
         };
         spyOnProperty(iframeContainer.$.iframe, 'contentWindow').and
             .returnValue({location: fakeLocation});
-        expect(iframeContainer.page).toBe(undefined);
         fakeLocation.href = 'http://testsite.com/foo/bar?name=blah#new-hash';
         iframeContainer.$.iframe.contentDocument
             .dispatchEvent(new Event('hashchange'));

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -381,7 +381,6 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             }
         }
         window.history.replaceState(null, null, l.toString());
-        this.set('routeHash.path', window.location.hash.substr(1));
     }
 
     /**


### PR DESCRIPTION
## summary

takes ownership of #141 (original author @hahahannes, inactive since August 2025). re-applied the fix on current main with failing unit tests fixed.

closes #65

## root cause

the iframe-container's `load` event listener attaches click and hashchange handlers but does not set `this.page` from the loaded iframe's current location. when a non-client-side navigation occurs inside the iframe (server-side redirect / GET request), the click event fires before the page property is initialized, causing the parent URL to either not update or update to a stale value.

additionally, `_iframePageChanged` in main-page.js calls `this.set('routeHash.path', ...)` after `window.history.replaceState`. this triggers the `_routePageChanged` observer a second time, creating a re-entrant state loop that produces incorrect URL synchronization.

## fix

1. **iframe-container.js**: set `this.page` from the iframe's location on the `load` event, before attaching click/hashchange listeners. this ensures the page property is always initialized to the current iframe location after navigation.

2. **main-page.js**: remove the redundant `this.set('routeHash.path', ...)` call. `window.history.replaceState` already updates the URL. the hash is reflected through the load event sync, making the explicit set unnecessary and harmful.

3. **iframe-container_test.js**: remove two `expect(page).toBe(undefined)` assertions. with the load-time sync, page is no longer undefined after beforeEach completes — it is set to the loaded iframe's path. the remaining assertions (click and hashchange update page to the expected value) are preserved.

## changes

| file | change |
|------|--------|
| `components/centraldashboard/public/components/iframe-container.js` | set `this.page` from iframe location on load event |
| `components/centraldashboard/public/components/main-page.js` | remove re-entrant `routeHash.path` set in `_iframePageChanged` |
| `components/centraldashboard/public/components/iframe-container_test.js` | remove stale `undefined` assertions for page property |

## what is not changed

- click and hashchange synchronization logic unchanged
- namespace message passing unchanged
- all other tests unmodified

cc @juliusvonkohout @andyatmiami @thesuperzapper
