### PR TITLE
fix: adopt pre-existing namespaces with no owner annotation

### DIFF
--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -171,24 +171,56 @@ func (r *ProfileReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 			return reconcile.Result{}, err
 		}
 	} else {
-		// Check exising namespace ownership before move forward
-		owner, ok := foundNs.Annotations["owner"]
-		if ok && owner == instance.Spec.Owner.Name {
-			oldLabels := map[string]string{}
-			for k, v := range foundNs.Labels {
-				oldLabels[k] = v
-			}
-			setNamespaceLabels(foundNs, defaultKubeflowNamespaceLabels)
-			logger.Info("List of labels to be added to found namespace", "labels", ns.Labels)
-			if !reflect.DeepEqual(oldLabels, foundNs.Labels) {
-				err = r.Update(ctx, foundNs)
-				if err != nil {
-					IncRequestErrorCounter("error updating namespace label", SEVERITY_MAJOR)
-					logger.Error(err, "error updating namespace label")
-					return reconcile.Result{}, err
-				}
-			}
-		} else {
+	    // Check existing namespace ownership before moving forward.
+	    //
+	    // A namespace that has no "owner" annotation at all has never been claimed
+	    // by any Profile (for example, it was created directly via
+	    // `kubectl create ns <name>` before the Profile CR existed). Such a
+	    // namespace is safe to adopt into this Profile rather than rejecting the
+	    // request outright. We only reject when the namespace is already owned by
+	    // a *different* user.
+	    owner, ok := foundNs.Annotations["owner"]
+	    if !ok || owner == instance.Spec.Owner.Name {
+	        oldLabels := map[string]string{}
+	        for k, v := range foundNs.Labels {
+	            oldLabels[k] = v
+	        }
+	        oldAnnotations := map[string]string{}
+	        for k, v := range foundNs.Annotations {
+	            oldAnnotations[k] = v
+	        }
+	
+	        if !ok {
+	            logger.Info("Adopting pre-existing namespace with no owner into Profile",
+	                "namespace", foundNs.Name, "owner", instance.Spec.Owner.Name)
+	            IncRequestCounter("adopt pre-existing namespace")
+	            if foundNs.Annotations == nil {
+	                foundNs.Annotations = map[string]string{}
+	            }
+	            foundNs.Annotations["owner"] = instance.Spec.Owner.Name
+	            if foundNs.Labels == nil {
+	                foundNs.Labels = map[string]string{}
+	            }
+	            if _, hasIstioLabel := foundNs.Labels[istioInjectionLabel]; !hasIstioLabel {
+	                foundNs.Labels[istioInjectionLabel] = "enabled"
+	            }
+	            if err := controllerutil.SetControllerReference(instance, foundNs, r.Scheme); err != nil {
+	                logger.Info("warning: could not set ControllerReference on adopted namespace",
+	                    "namespace", foundNs.Name, "error", err.Error())
+	            }
+	        }
+	
+	        setNamespaceLabels(foundNs, defaultKubeflowNamespaceLabels)
+	        logger.Info("List of labels to be added to found namespace", "labels", foundNs.Labels)
+	        if !reflect.DeepEqual(oldLabels, foundNs.Labels) || !reflect.DeepEqual(oldAnnotations, foundNs.Annotations) {
+	            err = r.Update(ctx, foundNs)
+	            if err != nil {
+	                IncRequestErrorCounter("error updating namespace label", SEVERITY_MAJOR)
+	                logger.Error(err, "error updating namespace label")
+	                return reconcile.Result{}, err
+	            }
+	        }
+	    } else {
 			logger.Info(fmt.Sprintf("namespace already exist, but not owned by profile creator %v",
 				instance.Spec.Owner.Name))
 			IncRequestCounter("reject profile taking over existing namespace")

--- a/components/profile-controller/controllers/profile_controller_test.go
+++ b/components/profile-controller/controllers/profile_controller_test.go
@@ -1,17 +1,26 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	profilev1 "github.com/kubeflow/dashboard/components/profile-controller/api/v1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
+	istiosecurityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 type namespaceLabelSuite struct {
@@ -23,7 +32,7 @@ type namespaceLabelSuite struct {
 func TestEnforceNamespaceLabelsFromConfig(t *testing.T) {
 	name := "test-namespace"
 	tests := []namespaceLabelSuite{
-		namespaceLabelSuite{
+		{
 			corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: name,
@@ -47,7 +56,7 @@ func TestEnforceNamespaceLabelsFromConfig(t *testing.T) {
 				},
 			},
 		},
-		namespaceLabelSuite{
+		{
 			corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -76,7 +85,7 @@ func TestEnforceNamespaceLabelsFromConfig(t *testing.T) {
 				},
 			},
 		},
-		namespaceLabelSuite{
+		{
 			corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -198,3 +207,184 @@ func createMockReconciler() *ProfileReconciler {
 	}
 	return reconciler
 }
+
+// =========================================================================
+// New Ginkgo tests — Namespace Adoption
+//
+// These run Reconcile() synchronously against a fake client (no envtest,
+// no live manager). Two reasons:
+//  1. This suite's BeforeSuite never starts a controller manager, so an
+//     Eventually()-style test against a live reconcile loop would just
+//     time out.
+//  2. Reconcile() also touches Istio's AuthorizationPolicy CRD, which
+//     isn't vendored for envtest in this repo — a real apiserver can't
+//     satisfy that request, but a fake client only needs the Go type
+//     registered in its scheme, not a real CRD installed.
+// =========================================================================
+
+// newFakeProfileReconciler builds a ProfileReconciler backed by a fresh
+// in-memory fake client seeded with the given objects.
+func newFakeProfileReconciler(objs ...client.Object) *ProfileReconciler {
+	scheme := runtime.NewScheme()
+	Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
+	Expect(profilev1.AddToScheme(scheme)).To(Succeed())
+	Expect(istiosecurityv1beta1.AddToScheme(scheme)).To(Succeed())
+
+	return &ProfileReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(objs...).
+			Build(),
+		Scheme: scheme,
+		Log:    ctrl.Log,
+		// readDefaultLabelsFromFile calls os.Exit(1) if this path doesn't
+		// resolve, so point it at the real default labels shipped with the
+		// manifests rather than a placeholder.
+		DefaultNamespaceLabelsPath: filepath.Join("..", "manifests", "kustomize", "base", "manager", "namespace-labels.yaml"),
+	}
+}
+
+var _ = Describe("Profile Controller - Namespace Adoption", func() {
+
+	ctx := context.Background()
+
+	bareNamespace := func(name string, annotations, labels map[string]string) *corev1.Namespace {
+		return &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Annotations: annotations,
+				Labels:      labels,
+			},
+		}
+	}
+
+	profileFor := func(name, owner string) *profilev1.Profile {
+		return &profilev1.Profile{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: profilev1.ProfileSpec{
+				Owner: rbacv1.Subject{Kind: "User", Name: owner},
+			},
+		}
+	}
+
+	reconcile := func(r *ProfileReconciler, name string) error {
+		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: name}})
+		return err
+	}
+
+	// ---------------------------------------------------------------
+	// Test 1: Namespace with NO owner annotation — should be adopted
+	// ---------------------------------------------------------------
+	Context("When a namespace exists with no owner annotation", func() {
+		const nsName = "adopt-no-owner"
+		const ownerName = "alice@example.com"
+
+		It("should adopt the namespace, set the owner annotation, apply default labels, and enable istio injection", func() {
+			ns := bareNamespace(nsName, nil, nil)
+			profile := profileFor(nsName, ownerName)
+			r := newFakeProfileReconciler(ns, profile)
+
+			Expect(reconcile(r, nsName)).To(Succeed())
+
+			var got corev1.Namespace
+			Expect(r.Get(ctx, types.NamespacedName{Name: nsName}, &got)).To(Succeed())
+			Expect(got.Annotations["owner"]).To(Equal(ownerName))
+			Expect(got.Labels["istio-injection"]).To(Equal("enabled"))
+			Expect(got.Labels).To(HaveKey("app.kubernetes.io/part-of"))
+
+			// The adopted namespace should now be owned by the Profile, so
+			// deleting the Profile will garbage-collect the namespace too.
+			Expect(got.OwnerReferences).To(HaveLen(1))
+			Expect(got.OwnerReferences[0].Kind).To(Equal("Profile"))
+			Expect(got.OwnerReferences[0].Name).To(Equal(nsName))
+			Expect(got.OwnerReferences[0].Controller).NotTo(BeNil())
+			Expect(*got.OwnerReferences[0].Controller).To(BeTrue())
+
+			var gotProfile profilev1.Profile
+			Expect(r.Get(ctx, types.NamespacedName{Name: nsName}, &gotProfile)).To(Succeed())
+			for _, c := range gotProfile.Status.Conditions {
+				Expect(c.Type).NotTo(Equal(profilev1.ProfileFailed))
+			}
+		})
+	})
+
+	// ---------------------------------------------------------------
+	// Test 2: Namespace already owned by the SAME user — update labels
+	// ---------------------------------------------------------------
+	Context("When a namespace exists already owned by the same user", func() {
+		const nsName = "same-owner-ns"
+		const ownerName = "bob@example.com"
+
+		It("should update labels without changing the owner annotation", func() {
+			ns := bareNamespace(nsName, map[string]string{"owner": ownerName}, nil)
+			profile := profileFor(nsName, ownerName)
+			r := newFakeProfileReconciler(ns, profile)
+
+			Expect(reconcile(r, nsName)).To(Succeed())
+
+			var got corev1.Namespace
+			Expect(r.Get(ctx, types.NamespacedName{Name: nsName}, &got)).To(Succeed())
+			Expect(got.Labels).To(HaveKey("app.kubernetes.io/part-of"))
+			Expect(got.Annotations["owner"]).To(Equal(ownerName))
+
+			// SetControllerReference is only called on first adoption (when
+			// the namespace had no owner annotation yet). A namespace that
+			// was already correctly owned before this fix existed should
+			// not retroactively gain an ownerReference.
+			Expect(got.OwnerReferences).To(BeEmpty())
+		})
+	})
+
+	// ---------------------------------------------------------------
+	// Test 3: Namespace owned by a DIFFERENT user — must be rejected
+	// ---------------------------------------------------------------
+	Context("When a namespace exists owned by a different user", func() {
+		const nsName = "different-owner-ns"
+		const existingOwner = "carol@example.com"
+		const newOwner = "dave@example.com"
+
+		It("should NOT overwrite the existing owner annotation, and should fail the Profile", func() {
+			ns := bareNamespace(nsName, map[string]string{"owner": existingOwner}, nil)
+			profile := profileFor(nsName, newOwner)
+			r := newFakeProfileReconciler(ns, profile)
+
+			// Reconcile itself returns nil here — it records a Failed
+			// condition on the Profile rather than returning an error,
+			// since this is an expected/handled outcome, not a transient
+			// failure that should be requeued.
+			Expect(reconcile(r, nsName)).To(Succeed())
+
+			var got corev1.Namespace
+			Expect(r.Get(ctx, types.NamespacedName{Name: nsName}, &got)).To(Succeed())
+			Expect(got.Annotations["owner"]).To(Equal(existingOwner))
+
+			var gotProfile profilev1.Profile
+			Expect(r.Get(ctx, types.NamespacedName{Name: nsName}, &gotProfile)).To(Succeed())
+			Expect(gotProfile.Status.Conditions).NotTo(BeEmpty())
+			lastCondition := gotProfile.Status.Conditions[len(gotProfile.Status.Conditions)-1]
+			Expect(lastCondition.Type).To(Equal(profilev1.ProfileFailed))
+		})
+	})
+
+	// ---------------------------------------------------------------
+	// Test 4: Namespace with existing Istio label — must NOT overwrite
+	// ---------------------------------------------------------------
+	Context("When a namespace already has a custom istio-injection label", func() {
+		const nsName = "custom-istio-ns"
+		const ownerName = "eve@example.com"
+
+		It("should preserve the existing istio-injection label value", func() {
+			ns := bareNamespace(nsName, nil, map[string]string{"istio-injection": "disabled"})
+			profile := profileFor(nsName, ownerName)
+			r := newFakeProfileReconciler(ns, profile)
+
+			Expect(reconcile(r, nsName)).To(Succeed())
+
+			var got corev1.Namespace
+			Expect(r.Get(ctx, types.NamespacedName{Name: nsName}, &got)).To(Succeed())
+			Expect(got.Labels["istio-injection"]).To(Equal("disabled"))
+			Expect(got.Annotations["owner"]).To(Equal(ownerName))
+		})
+	})
+})


### PR DESCRIPTION
## Problem

The Profile controller rejects a namespace that already exists when its
Profile CR is applied, unless the namespace already has a matching
`owner` annotation. A namespace created via `kubectl create ns` (no
annotation at all) was always rejected, even with no other claimant.

## Fix

Adopt the namespace when it has no `owner` annotation yet (nothing has
claimed it), and continue to reject only when it's owned by a different
user. On adoption, also set a controller `OwnerReference` so the
namespace is garbage-collected with its Profile, matching the behavior
of namespaces this controller creates itself.

## Testing
### Unit Tests

Added unit tests in profile_controller_test.go covering the following scenarios:

- Adoption of an existing namespace without an owner annotation.
- Verification that an OwnerReference is added during namespace adoption.
- Existing namespace already owned by the same user.
- Existing namespace owned by a different user (Profile reconciliation is rejected).
- Preservation of an existing custom istio-injection label during adoption.

All unit tests pass successfully.

_make test_

### Manual Validation

The changes were verified on a local Kind cluster by:

1. Building the updated Dashboard image.
2. Deploying the custom image.
3. Creating a namespace using:
    _kubectl create namespace test-profile_
4. Applying a corresponding Profile resource.
5. Verifying that:
    - the existing namespace is successfully adopted;
    - the owner annotation is added;
    - the Profile is set as the controller OwnerReference;
    - default namespace labels are applied;
    - existing custom labels (including istio-injection) are preserved.
6. Verifying that a namespace already owned by another user continues to be rejected.

related: #330 
closes: #330 