### PR TITLE
fix(kfam): use routed profile name in delete handler

### DIFF
--- a/components/access-management/kfam/api_default.go
+++ b/components/access-management/kfam/api_default.go
@@ -14,11 +14,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
-	"path"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/gorilla/mux"
 	profileRegister "github.com/kubeflow/dashboard/components/access-management/pkg/apis/kubeflow/v1beta1"
 	profilev1beta1 "github.com/kubeflow/dashboard/components/profile-controller/api/v1beta1"
 	log "github.com/sirupsen/logrus"
@@ -206,7 +206,7 @@ func (c *KfamV1Alpha1Client) DeleteProfile(w http.ResponseWriter, r *http.Reques
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	const action = "delete"
 	useremail := c.getUserEmail(r.Header)
-	profileName := path.Base(r.RequestURI)
+	profileName := mux.Vars(r)["profile"]
 	// check permission before delete
 	if c.isOwnerOrAdmin(useremail, profileName) {
 		err := c.profileClient.Delete(profileName, nil)

--- a/components/access-management/kfam/delete_profile_test.go
+++ b/components/access-management/kfam/delete_profile_test.go
@@ -1,0 +1,84 @@
+package kfam
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	profilev1beta1 "github.com/kubeflow/dashboard/components/profile-controller/api/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type stubProfileClient struct {
+	getName    string
+	deleteName string
+}
+
+func (s *stubProfileClient) Create(profile *profilev1beta1.Profile) (*profilev1beta1.Profile, error) {
+	return profile, nil
+}
+
+func (s *stubProfileClient) Delete(name string, opts *metav1.DeleteOptions) error {
+	s.deleteName = name
+	return nil
+}
+
+func (s *stubProfileClient) Get(name string, opts metav1.GetOptions) (*profilev1beta1.Profile, error) {
+	s.getName = name
+	return &profilev1beta1.Profile{
+		Spec: profilev1beta1.ProfileSpec{
+			Owner: rbacv1.Subject{
+				Name: "user@example.com",
+			},
+		},
+	}, nil
+}
+
+func (s *stubProfileClient) List(opts metav1.ListOptions) (*profilev1beta1.ProfileList, error) {
+	return &profilev1beta1.ProfileList{}, nil
+}
+
+func (s *stubProfileClient) Update(profile *profilev1beta1.Profile) (*profilev1beta1.Profile, error) {
+	return profile, nil
+}
+
+type stubBindingClient struct{}
+
+func (s *stubBindingClient) Create(binding *Binding, userIdHeader string, userIdPrefix string) error {
+	return nil
+}
+
+func (s *stubBindingClient) Delete(binding *Binding) error {
+	return nil
+}
+
+func (s *stubBindingClient) List(user string, namespaces []string, role string) (*BindingEntries, error) {
+	return &BindingEntries{}, nil
+}
+
+func TestDeleteProfileUsesPathVariable(t *testing.T) {
+	profileClient := &stubProfileClient{}
+	client := &KfamV1Alpha1Client{
+		profileClient: profileClient,
+		bindingClient: &stubBindingClient{},
+		userIdHeader:  "x-user",
+		userIdPrefix:  "accounts.google.com:",
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/kfam/v1/profiles/test-profile?dryRun=All", nil)
+	req.Header.Set("x-user", "accounts.google.com:user@example.com")
+	rec := httptest.NewRecorder()
+
+	NewRouter(client).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: got %d want %d", rec.Code, http.StatusOK)
+	}
+	if profileClient.getName != "test-profile" {
+		t.Fatalf("profile lookup used %q, want %q", profileClient.getName, "test-profile")
+	}
+	if profileClient.deleteName != "test-profile" {
+		t.Fatalf("profile delete used %q, want %q", profileClient.deleteName, "test-profile")
+	}
+}


### PR DESCRIPTION
This fixes profile deletes when the request has a query string.

Right now `DeleteProfile` uses `path.Base(r.RequestURI)`, so `DELETE /kfam/v1/profiles/test-profile?dryRun=All` ends up looking for `test-profile?dryRun=All` and the delete misses. Kinda sneaky.

The fix is small: read `{profile}` from the mux route var instead of the raw request URI. Added a regression test too, just to lock it in.

Repro:
1. Run `cd components/access-management && make test`.
2. Before the fix, `path.Base("/kfam/v1/profiles/test-profile?dryRun=All")` returns `test-profile?dryRun=All`.
3. Send `DELETE /kfam/v1/profiles/test-profile?dryRun=All` to KFAM.
4. Before this change the handler uses the wrong profile name, after this change it uses `test-profile` and goes through.
