### PR TITLE
fix: synchronize parent URL on in-iframe hash and history navigation

### DIFF
--- a/components/centraldashboard/karma.conf.js
+++ b/components/centraldashboard/karma.conf.js
@@ -23,6 +23,13 @@ module.exports = (config) => config.set({
     frameworks: ['jasmine'],
     files: [
         'public/index_test.js',
+        /* Served-only fixtures for real iframe navigation tests. */
+        {
+            pattern: 'test_fixtures/*.html',
+            included: false,
+            served: true,
+            watched: false,
+        },
     ],
     exclude: [],
     preprocessors: {

--- a/components/centraldashboard/public/components/iframe-container.js
+++ b/components/centraldashboard/public/components/iframe-container.js
@@ -63,22 +63,14 @@ export class IframeContainer extends PolymerElement {
             }
         };
         iframe.addEventListener('load', () => {
-            // Synchronize the page property on load so that server-side
-            // navigations are captured before any click or hashchange event.
-            // Non-HTTP(S) documents such as about:blank are skipped: their
-            // opaque origin serializes to "null", which would produce an
-            // invalid page value and corrupt the parent URL through the
-            // two-way page binding.
+            // Skip non-HTTP(S) documents (about:blank) whose opaque
+            // origin would corrupt the parent URL binding.
             const {protocol} = iframe.contentWindow.location;
             if (protocol === 'http:' || protocol === 'https:') {
                 this._syncIframePage();
             }
-            // hashchange and popstate are Window events; a Document listener
-            // never receives them, so in-iframe hash navigation (for example
-            // the hash-routed Pipelines web application) was never synced.
-            // The stable listener reference makes re-attachment on every load
-            // a no-op when the browser reuses the Window, and a fresh attach
-            // when navigation replaced it.
+            // hashchange and popstate are Window events; attach to
+            // contentWindow so in-iframe hash navigation syncs.
             const {contentDocument, contentWindow} = iframe;
             contentDocument.addEventListener('click', this._syncIframePage);
             contentWindow.addEventListener('hashchange', this._syncIframePage);

--- a/components/centraldashboard/public/components/iframe-container.js
+++ b/components/centraldashboard/public/components/iframe-container.js
@@ -73,9 +73,13 @@ export class IframeContainer extends PolymerElement {
             if (protocol === 'http:' || protocol === 'https:') {
                 syncIframePage();
             }
-            const {contentDocument} = iframe;
+            const {contentDocument, contentWindow} = iframe;
             contentDocument.addEventListener('click', syncIframePage);
-            contentDocument.addEventListener('hashchange', syncIframePage);
+            // hashchange and popstate are Window events; a Document listener
+            // never receives them, so in-iframe hash navigation (for example
+            // the hash-routed Pipelines web application) was never synced.
+            contentWindow.addEventListener('hashchange', syncIframePage);
+            contentWindow.addEventListener('popstate', syncIframePage);
         });
     }
 

--- a/components/centraldashboard/public/components/iframe-container.js
+++ b/components/centraldashboard/public/components/iframe-container.js
@@ -54,15 +54,15 @@ export class IframeContainer extends PolymerElement {
         // Adds a click handler to be able to capture navigation events from
         // the captured iframe and set the page property which notifies
         const iframe = this.$.iframe;
+        this._syncIframePage = () => {
+            const iframeLocation = iframe.contentWindow.location;
+            const newIframePage = iframeLocation.href.slice(
+                iframeLocation.origin.length);
+            if (this.page !== newIframePage) {
+                this.page = newIframePage;
+            }
+        };
         iframe.addEventListener('load', () => {
-            const syncIframePage = () => {
-                const iframeLocation = iframe.contentWindow.location;
-                const newIframePage = iframeLocation.href.slice(
-                    iframeLocation.origin.length);
-                if (this.page !== newIframePage) {
-                    this.page = newIframePage;
-                }
-            };
             // Synchronize the page property on load so that server-side
             // navigations are captured before any click or hashchange event.
             // Non-HTTP(S) documents such as about:blank are skipped: their
@@ -71,15 +71,18 @@ export class IframeContainer extends PolymerElement {
             // two-way page binding.
             const {protocol} = iframe.contentWindow.location;
             if (protocol === 'http:' || protocol === 'https:') {
-                syncIframePage();
+                this._syncIframePage();
             }
-            const {contentDocument, contentWindow} = iframe;
-            contentDocument.addEventListener('click', syncIframePage);
             // hashchange and popstate are Window events; a Document listener
             // never receives them, so in-iframe hash navigation (for example
             // the hash-routed Pipelines web application) was never synced.
-            contentWindow.addEventListener('hashchange', syncIframePage);
-            contentWindow.addEventListener('popstate', syncIframePage);
+            // The stable listener reference makes re-attachment on every load
+            // a no-op when the browser reuses the Window, and a fresh attach
+            // when navigation replaced it.
+            const {contentDocument, contentWindow} = iframe;
+            contentDocument.addEventListener('click', this._syncIframePage);
+            contentWindow.addEventListener('hashchange', this._syncIframePage);
+            contentWindow.addEventListener('popstate', this._syncIframePage);
         });
     }
 

--- a/components/centraldashboard/public/components/iframe-container_test.js
+++ b/components/centraldashboard/public/components/iframe-container_test.js
@@ -80,8 +80,7 @@ describe('Iframe Container', () => {
     });
 
     it('Should reflect iframe URL changes on hashchange event', async () => {
-        // Capture the real Window before the spy replaces the property, since
-        // hashchange listeners are attached to the Window on load.
+        // Capture the real Window before the spy replaces the property.
         const realContentWindow = iframeContainer.$.iframe.contentWindow;
         const fakeLocation = {
             href: 'http://testsite.com/foo/bar?name=blah',
@@ -170,10 +169,7 @@ describe('Iframe Container', () => {
     });
 });
 
-// Drives the component with real navigations inside a served fixture page
-// instead of a mocked contentWindow. The mocked hashchange test above passed
-// for years while the listener was attached to the Document, where Window
-// events never fire in a real browser; these tests close that blind spot.
+// Real navigations against served fixtures (no mocked contentWindow).
 describe('Iframe Container real navigation', () => {
     const FIXTURE_URL = '/base/test_fixtures/hash-routed-app.html';
     const FIXTURE_SECOND_PAGE_URL =

--- a/components/centraldashboard/public/components/iframe-container_test.js
+++ b/components/centraldashboard/public/components/iframe-container_test.js
@@ -196,10 +196,10 @@ describe('Iframe Container real navigation', () => {
             poll();
         });
 
-    const loadFixture = (url) => new Promise((resolve) => {
-        container.$.iframe.addEventListener('load', resolve, {once: true});
+    const loadFixture = async (url) => {
         container.src = url;
-    });
+        await waitForPage(url);
+    };
 
     beforeEach(() => {
         container = document.createElement('iframe-container');
@@ -232,12 +232,8 @@ describe('Iframe Container real navigation', () => {
     it('Should re-attach listeners after a full document navigation inside ' +
         'the iframe', async () => {
         await loadFixture(FIXTURE_URL);
-        const nextLoad = new Promise((resolve) => {
-            container.$.iframe.addEventListener('load', resolve, {once: true});
-        });
         container.$.iframe.contentDocument
             .getElementById('second-page-link').click();
-        await nextLoad;
         await waitForPage(FIXTURE_SECOND_PAGE_URL);
         container.$.iframe.contentDocument
             .getElementById('second-details-link').click();

--- a/components/centraldashboard/public/components/iframe-container_test.js
+++ b/components/centraldashboard/public/components/iframe-container_test.js
@@ -80,6 +80,9 @@ describe('Iframe Container', () => {
     });
 
     it('Should reflect iframe URL changes on hashchange event', async () => {
+        // Capture the real Window before the spy replaces the property, since
+        // hashchange listeners are attached to the Window on load.
+        const realContentWindow = iframeContainer.$.iframe.contentWindow;
         const fakeLocation = {
             href: 'http://testsite.com/foo/bar?name=blah',
             origin: 'http://testsite.com',
@@ -88,9 +91,22 @@ describe('Iframe Container', () => {
             .returnValue({location: fakeLocation});
         expect(iframeContainer.page).toBe(undefined);
         fakeLocation.href = 'http://testsite.com/foo/bar?name=blah#new-hash';
-        iframeContainer.$.iframe.contentDocument
-            .dispatchEvent(new Event('hashchange'));
+        realContentWindow.dispatchEvent(new Event('hashchange'));
         expect(iframeContainer.page).toBe('/foo/bar?name=blah#new-hash');
+    });
+
+    it('Should reflect iframe URL changes on popstate event', async () => {
+        const realContentWindow = iframeContainer.$.iframe.contentWindow;
+        const fakeLocation = {
+            href: 'http://testsite.com/foo/bar?name=blah',
+            origin: 'http://testsite.com',
+        };
+        spyOnProperty(iframeContainer.$.iframe, 'contentWindow').and
+            .returnValue({location: fakeLocation});
+        expect(iframeContainer.page).toBe(undefined);
+        fakeLocation.href = 'http://testsite.com/previous/page';
+        realContentWindow.dispatchEvent(new Event('popstate'));
+        expect(iframeContainer.page).toBe('/previous/page');
     });
 
     it('Should synchronize page property when an HTTP page loads',
@@ -101,6 +117,7 @@ describe('Iframe Container', () => {
                     origin: 'http://testsite.com',
                     protocol: 'http:',
                 },
+                addEventListener: () => {},
                 postMessage: () => {},
             };
             spyOnProperty(iframeContainer.$.iframe, 'contentWindow').and
@@ -117,6 +134,7 @@ describe('Iframe Container', () => {
                 origin: 'null',
                 protocol: 'about:',
             },
+            addEventListener: () => {},
             postMessage: () => {},
         };
         spyOnProperty(iframeContainer.$.iframe, 'contentWindow').and
@@ -149,5 +167,81 @@ describe('Iframe Container', () => {
             },
             origin,
         ]);
+    });
+});
+
+// Drives the component with real navigations inside a served fixture page
+// instead of a mocked contentWindow. The mocked hashchange test above passed
+// for years while the listener was attached to the Document, where Window
+// events never fire in a real browser; these tests close that blind spot.
+describe('Iframe Container real navigation', () => {
+    const FIXTURE_URL = '/base/test_fixtures/hash-routed-app.html';
+    const FIXTURE_SECOND_PAGE_URL =
+        '/base/test_fixtures/hash-routed-app-second-page.html';
+
+    let container;
+
+    const waitForPage = (expectedPage, timeoutMilliseconds = 3000) =>
+        new Promise((resolve, reject) => {
+            const startTime = Date.now();
+            const poll = () => {
+                if (container.page === expectedPage) return resolve();
+                if (Date.now() - startTime > timeoutMilliseconds) {
+                    return reject(new Error(
+                        `timed out waiting for page "${expectedPage}", ` +
+                        `page is "${container.page}"`));
+                }
+                setTimeout(poll, 25);
+            };
+            poll();
+        });
+
+    const loadFixture = (url) => new Promise((resolve) => {
+        container.$.iframe.addEventListener('load', resolve, {once: true});
+        container.src = url;
+    });
+
+    beforeEach(() => {
+        container = document.createElement('iframe-container');
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    it('Should sync page when a hash link is clicked inside the iframe',
+        async () => {
+            await loadFixture(FIXTURE_URL);
+            expect(container.page).toBe(FIXTURE_URL);
+            container.$.iframe.contentDocument
+                .getElementById('details-link').click();
+            await waitForPage(`${FIXTURE_URL}#/details/123`);
+        });
+
+    it('Should sync page on history back inside the iframe', async () => {
+        await loadFixture(FIXTURE_URL);
+        container.$.iframe.contentDocument
+            .getElementById('details-link').click();
+        await waitForPage(`${FIXTURE_URL}#/details/123`);
+        container.$.iframe.contentWindow.history.back();
+        await waitForPage(FIXTURE_URL);
+        expect(container.page).toBe(FIXTURE_URL);
+    });
+
+    it('Should re-attach listeners after a full document navigation inside ' +
+        'the iframe', async () => {
+        await loadFixture(FIXTURE_URL);
+        const nextLoad = new Promise((resolve) => {
+            container.$.iframe.addEventListener('load', resolve, {once: true});
+        });
+        container.$.iframe.contentDocument
+            .getElementById('second-page-link').click();
+        await nextLoad;
+        await waitForPage(FIXTURE_SECOND_PAGE_URL);
+        container.$.iframe.contentDocument
+            .getElementById('second-details-link').click();
+        await waitForPage(`${FIXTURE_SECOND_PAGE_URL}#/second/456`);
+        expect(container.page).toBe(`${FIXTURE_SECOND_PAGE_URL}#/second/456`);
     });
 });

--- a/components/centraldashboard/test_fixtures/hash-routed-app-second-page.html
+++ b/components/centraldashboard/test_fixtures/hash-routed-app-second-page.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>hash routed application fixture second page</title></head>
+<body>
+<a id="second-details-link" href="#/second/456">second details</a>
+</body>
+</html>

--- a/components/centraldashboard/test_fixtures/hash-routed-app.html
+++ b/components/centraldashboard/test_fixtures/hash-routed-app.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><title>hash routed application fixture</title></head>
+<body>
+<a id="details-link" href="#/details/123">details</a>
+<a id="second-page-link" href="hash-routed-app-second-page.html">second page</a>
+</body>
+</html>


### PR DESCRIPTION
### summary

follow-up to #303, addressing the glitch @andyatmiami demonstrated after merge: clicking a hash-routed link inside the iframe (for example a pipeline details link on the shared tab) updates the iframe content but leaves the browser bar stale, so a refresh navigates away from the page. scope confirmed with @juliusvonkohout, including the real-navigation regression tests.

### root cause

hashchange and popstate are Window events. the iframe load handler attached the hashchange listener to the iframe's Document, where these events never fire in a real browser — the existing unit test only passed because it dispatched the event synthetically on the document. the click listener runs before the browser performs the navigation, so it reads the pre-navigation url. in-iframe hash navigation therefore never synced the parent url.

### fix

| file | change |
|------|--------|
| public/components/iframe-container.js | attach hashchange and popstate listeners to the iframe Window instead of the Document |
| public/components/iframe-container_test.js | hashchange test dispatches on the Window as a real browser does; new popstate test; new real-navigation suite |
| karma.conf.js | serve the test fixture pages |
| test_fixtures/hash-routed-app.html, test_fixtures/hash-routed-app-second-page.html | hash-routed fixture pages driven by the real-navigation tests |

popstate also covers history back/forward navigation inside the iframe.

### real-navigation regression tests

the mocked contentWindow tests are how the dead Document listener survived for years, so this adds three tests that drive the component against served fixture pages with no mocks: a real hash link click, history.back(), and a full document navigation followed by another hash click (proves listeners re-attach to the new Window). verified against the previous implementation: all three fail on main, all pass with this change.

### not covered

pushState-only routing inside an iframe still does not sync on click (the click listener fires before navigation). the kubeflow web applications are hash-routed, so this covers the demonstrated cases.

### tests

74 frontend unit tests pass (71 existing + 3 real-navigation); eslint clean.

fixes the behavior shown in https://github.com/kubeflow/dashboard/pull/303#issuecomment (andy's post-merge comment)

cc @juliusvonkohout @andyatmiami
