### PR TITLE
improve: self-service UI adding viewers in addition to editors

### DIFF
--- a/components/centraldashboard/app/api_workgroup.ts
+++ b/components/centraldashboard/app/api_workgroup.ts
@@ -223,39 +223,52 @@ export class WorkgroupApi {
             Object.keys(headers).forEach(
                 (key) => authHeaders.includes(key) || delete headers[key]
             );
-            let resolvedRole = role;
+            let oldBinding: WorkgroupBinding | null = null;
             if (action === 'remove') {
                 const existing = await this.getContributors(namespace);
-                const match = existing.find((b) => b.user === contributor);
+                const match = existing.find(
+                    (b) => b.user === contributor && b.role === role
+                );
                 if (!match) {
                     return apiError({
                         res,
-                        error: `${contributor} is not a contributor or viewer of ${namespace}`,
+                        error: `${contributor} is not a ${role} of ${namespace}`,
                     });
                 }
-                resolvedRole = match.role;
             }
             if (action === 'create') {
                 const existing = await this.getContributors(namespace);
                 const match = existing.find((b) => b.user === contributor);
                 if (match && match.role !== role) {
-                    // Different role: remove old binding before creating new one
-                    const oldBinding = mapSimpleBindingToWorkgroupBinding({
+                    oldBinding = mapSimpleBindingToWorkgroupBinding({
                         user: contributor,
                         namespace,
                         role: match.role,
                     });
-                    await profilesService.deleteBinding(oldBinding, {headers});
                 }
                 // Same role: fall through to createBinding → kfam will error "already exists"
             }
             const binding = mapSimpleBindingToWorkgroupBinding({
                 user: contributor,
                 namespace,
-                role: resolvedRole,
+                role,
             });
             const actionAPI = action === 'create' ? 'createBinding' : 'deleteBinding';
             await profilesService[actionAPI](binding, {headers});
+            // A failure here means the user has both bindings temporarily;
+            // surface a clear message so the operator knows cleanup is needed.
+            if (oldBinding) {
+                try {
+                    await profilesService.deleteBinding(oldBinding, {headers});
+                } catch (cleanupErr) {
+                    return surfaceProfileControllerErrors({
+                        res,
+                        msg: `Role updated but failed to remove existing assignment` +
+                            ` for ${contributor} in ${namespace}.`,
+                        err: cleanupErr,
+                    });
+                }
+            }
             errIndex++;
             const users = await this.getContributors(namespace);
             res.json(users);
@@ -422,6 +435,9 @@ export class WorkgroupApi {
         })
         .delete('/remove-contributor/:namespace', async (req: Request, res: Response) => {
             this.handleContributor('remove', 'contributor', req, res);
+        })
+        .delete('/remove-viewer/:namespace', async (req: Request, res: Response) => {
+            this.handleContributor('remove', 'viewer', req, res);
         });
     }
 }

--- a/components/centraldashboard/app/api_workgroup.ts
+++ b/components/centraldashboard/app/api_workgroup.ts
@@ -21,6 +21,7 @@ interface CreateProfileRequest {
 
 interface AddOrRemoveContributorRequest {
     contributor?: string;
+    role?: SimpleRole;
 }
 
 interface HasWorkgroupResponse {
@@ -191,7 +192,7 @@ export class WorkgroupApi {
     }
     async handleContributor(action: ContributorActions, req: Request, res: Response) {
         const {namespace} = req.params;
-        const {contributor} = req.body as AddOrRemoveContributorRequest;
+        const {contributor, role = 'contributor'} = req.body as AddOrRemoveContributorRequest;
         const {profilesService} = this;
         if (!contributor || !namespace) {
             const missing = [];
@@ -210,12 +211,30 @@ export class WorkgroupApi {
                 error: `Contributor doesn't look like a valid email address`,
             });
         }
+        if (action === 'create' && role !== 'contributor' && role !== 'viewer') {
+            return apiError({
+                res,
+                error: `Invalid role: must be 'contributor' or 'viewer'`,
+            });
+        }
         let errIndex = 0;
         try {
+            let resolvedRole = role;
+            if (action === 'remove') {
+                const existing = await this.getContributors(namespace);
+                const match = existing.find((b) => b.user === contributor);
+                if (!match) {
+                    return apiError({
+                        res,
+                        error: `${contributor} is not a contributor or viewer of ${namespace}`,
+                    });
+                }
+                resolvedRole = match.role;
+            }
             const binding = mapSimpleBindingToWorkgroupBinding({
                 user: contributor,
                 namespace,
-                role: 'contributor',
+                role: resolvedRole,
             });
             // only pass the auth-related headers from the user's request on to kfam
             const authHeaders = ['authorization', 'cookie', this.userIdHeader];
@@ -241,16 +260,15 @@ export class WorkgroupApi {
         }
     }
     /**
-     * Given an owned namespace, list all contributors under it
+     * Given an owned namespace, list all contributors and viewers under it
      * @param namespace Namespace to find contributors for
      */
     async getContributors(namespace: string) {
         const {body} = await this.profilesService
             .readBindings(undefined, namespace);
-        const users = mapWorkgroupBindingToSimpleBinding(body.bindings)
-            .filter((b) => b.role === 'contributor')
-            .map((b) => b.user);
-        return users;
+        return mapWorkgroupBindingToSimpleBinding(body.bindings)
+            .filter((b) => b.role === 'contributor' || b.role === 'viewer')
+            .map((b) => ({user: b.user, role: b.role}));
     }
     routes() {return Router()
         .get('/exists', async (req: Request, res: Response) => {

--- a/components/centraldashboard/app/api_workgroup.ts
+++ b/components/centraldashboard/app/api_workgroup.ts
@@ -21,7 +21,6 @@ interface CreateProfileRequest {
 
 interface AddOrRemoveContributorRequest {
     contributor?: string;
-    role?: SimpleRole;
 }
 
 interface HasWorkgroupResponse {
@@ -190,9 +189,14 @@ export class WorkgroupApi {
             namespaces,
         };
     }
-    async handleContributor(action: ContributorActions, req: Request, res: Response) {
+    async handleContributor(
+        action: ContributorActions,
+        role: SimpleRole,
+        req: Request,
+        res: Response,
+    ) {
         const {namespace} = req.params;
-        const {contributor, role = 'contributor'} = req.body as AddOrRemoveContributorRequest;
+        const {contributor} = req.body as AddOrRemoveContributorRequest;
         const {profilesService} = this;
         if (!contributor || !namespace) {
             const missing = [];
@@ -209,12 +213,6 @@ export class WorkgroupApi {
             return apiError({
                 res,
                 error: `Contributor doesn't look like a valid email address`,
-            });
-        }
-        if (action === 'create' && role !== 'contributor' && role !== 'viewer') {
-            return apiError({
-                res,
-                error: `Invalid role: must be 'contributor' or 'viewer'`,
             });
         }
         let errIndex = 0;
@@ -417,10 +415,13 @@ export class WorkgroupApi {
             }
         })
         .post('/add-contributor/:namespace', async (req: Request, res: Response) => {
-            this.handleContributor('create', req, res);
+            this.handleContributor('create', 'contributor', req, res);
+        })
+        .post('/add-viewer/:namespace', async (req: Request, res: Response) => {
+            this.handleContributor('create', 'viewer', req, res);
         })
         .delete('/remove-contributor/:namespace', async (req: Request, res: Response) => {
-            this.handleContributor('remove', req, res);
+            this.handleContributor('remove', 'contributor', req, res);
         });
     }
 }

--- a/components/centraldashboard/app/api_workgroup.ts
+++ b/components/centraldashboard/app/api_workgroup.ts
@@ -256,17 +256,19 @@ export class WorkgroupApi {
             const actionAPI = action === 'create' ? 'createBinding' : 'deleteBinding';
             await profilesService[actionAPI](binding, {headers});
             // A failure here means the user has both bindings temporarily;
-            // surface a clear message so the operator knows cleanup is needed.
+            // try rolling back and surface a clear message so the operator knows if cleanup is needed.
             if (oldBinding) {
                 try {
                     await profilesService.deleteBinding(oldBinding, {headers});
                 } catch (cleanupErr) {
-                    return surfaceProfileControllerErrors({
-                        res,
-                        msg: `Role updated but failed to remove existing assignment` +
-                            ` for ${contributor} in ${namespace}.`,
-                        err: cleanupErr,
-                    });
+                    let msg = `Role updated but failed to remove existing assignment` +
+                        ` for ${contributor} in ${namespace}. Manual cleanup required.`;
+                    try {
+                        await profilesService.deleteBinding(binding, {headers});
+                        msg = `Failed to remove existing assignment for ${contributor}` +
+                            ` in ${namespace}. Role change was not applied.`;
+                    } catch (_rollbackErr) { /* best-effort */ }
+                    return surfaceProfileControllerErrors({res, msg, err: cleanupErr});
                 }
             }
             errIndex++;

--- a/components/centraldashboard/app/api_workgroup.ts
+++ b/components/centraldashboard/app/api_workgroup.ts
@@ -219,6 +219,12 @@ export class WorkgroupApi {
         }
         let errIndex = 0;
         try {
+            // only pass the auth-related headers from the user's request on to kfam
+            const authHeaders = ['authorization', 'cookie', this.userIdHeader];
+            const {headers} = req;
+            Object.keys(headers).forEach(
+                (key) => authHeaders.includes(key) || delete headers[key]
+            );
             let resolvedRole = role;
             if (action === 'remove') {
                 const existing = await this.getContributors(namespace);
@@ -231,17 +237,25 @@ export class WorkgroupApi {
                 }
                 resolvedRole = match.role;
             }
+            if (action === 'create') {
+                const existing = await this.getContributors(namespace);
+                const match = existing.find((b) => b.user === contributor);
+                if (match && match.role !== role) {
+                    // Different role: remove old binding before creating new one
+                    const oldBinding = mapSimpleBindingToWorkgroupBinding({
+                        user: contributor,
+                        namespace,
+                        role: match.role,
+                    });
+                    await profilesService.deleteBinding(oldBinding, {headers});
+                }
+                // Same role: fall through to createBinding → kfam will error "already exists"
+            }
             const binding = mapSimpleBindingToWorkgroupBinding({
                 user: contributor,
                 namespace,
                 role: resolvedRole,
             });
-            // only pass the auth-related headers from the user's request on to kfam
-            const authHeaders = ['authorization', 'cookie', this.userIdHeader];
-            const {headers} = req;
-            Object.keys(headers).forEach(
-                (key) => authHeaders.includes(key) || delete headers[key]
-            );
             const actionAPI = action === 'create' ? 'createBinding' : 'deleteBinding';
             await profilesService[actionAPI](binding, {headers});
             errIndex++;

--- a/components/centraldashboard/app/api_workgroup.ts
+++ b/components/centraldashboard/app/api_workgroup.ts
@@ -262,22 +262,18 @@ export class WorkgroupApi {
             if (!requestedBindingExists) {
                 await profilesService[actionAPI](binding, {headers});
             }
-            // A failure here means the user has both bindings temporarily;
-            // try rolling back and surface a clear message so the operator knows if cleanup is needed.
+            // A failure here can occur after KFAM removed the old RoleBinding.
+            // Keep the new binding so the user does not lose all RBAC access.
             if (oldBinding) {
                 try {
                     await profilesService.deleteBinding(oldBinding, {headers});
                 } catch (cleanupErr) {
-                    let msg = `Role updated but failed to remove existing assignment` +
+                    const msg = `Role updated but failed to remove existing assignment` +
                         ` for ${contributor} in ${namespace}. Manual cleanup required.`;
-                    if (!requestedBindingExists) {
-                        try {
-                            await profilesService.deleteBinding(binding, {headers});
-                            msg = `Failed to remove existing assignment for ${contributor}` +
-                                ` in ${namespace}. Role change was not applied.`;
-                        } catch (_rollbackErr) { /* best-effort */ }
-                    }
-                    return surfaceProfileControllerErrors({res, msg, err: cleanupErr});
+                    const code = (cleanupErr.response && cleanupErr.response.statusCode) || 400;
+                    const detail = cleanupErr.body ? ` ${cleanupErr.body}` : '';
+                    console.error(`${msg}${detail}`, cleanupErr.stack ? cleanupErr : '');
+                    return apiError({res, code, error: `${msg}${detail}`});
                 }
             }
             errIndex++;

--- a/components/centraldashboard/app/api_workgroup.ts
+++ b/components/centraldashboard/app/api_workgroup.ts
@@ -224,6 +224,7 @@ export class WorkgroupApi {
                 (key) => authHeaders.includes(key) || delete headers[key]
             );
             let oldBinding: WorkgroupBinding | null = null;
+            let requestedBindingExists = false;
             if (action === 'remove') {
                 const existing = await this.getContributors(namespace);
                 const match = existing.find(
@@ -238,15 +239,19 @@ export class WorkgroupApi {
             }
             if (action === 'create') {
                 const existing = await this.getContributors(namespace);
-                const match = existing.find((b) => b.user === contributor);
-                if (match && match.role !== role) {
+                requestedBindingExists = existing.some(
+                    (binding) => binding.user === contributor && binding.role === role
+                );
+                const match = existing.find(
+                    (binding) => binding.user === contributor && binding.role !== role
+                );
+                if (match) {
                     oldBinding = mapSimpleBindingToWorkgroupBinding({
                         user: contributor,
                         namespace,
                         role: match.role,
                     });
                 }
-                // Same role: fall through to createBinding → kfam will error "already exists"
             }
             const binding = mapSimpleBindingToWorkgroupBinding({
                 user: contributor,
@@ -254,7 +259,9 @@ export class WorkgroupApi {
                 role,
             });
             const actionAPI = action === 'create' ? 'createBinding' : 'deleteBinding';
-            await profilesService[actionAPI](binding, {headers});
+            if (!requestedBindingExists) {
+                await profilesService[actionAPI](binding, {headers});
+            }
             // A failure here means the user has both bindings temporarily;
             // try rolling back and surface a clear message so the operator knows if cleanup is needed.
             if (oldBinding) {
@@ -263,11 +270,13 @@ export class WorkgroupApi {
                 } catch (cleanupErr) {
                     let msg = `Role updated but failed to remove existing assignment` +
                         ` for ${contributor} in ${namespace}. Manual cleanup required.`;
-                    try {
-                        await profilesService.deleteBinding(binding, {headers});
-                        msg = `Failed to remove existing assignment for ${contributor}` +
-                            ` in ${namespace}. Role change was not applied.`;
-                    } catch (_rollbackErr) { /* best-effort */ }
+                    if (!requestedBindingExists) {
+                        try {
+                            await profilesService.deleteBinding(binding, {headers});
+                            msg = `Failed to remove existing assignment for ${contributor}` +
+                                ` in ${namespace}. Role change was not applied.`;
+                        } catch (_rollbackErr) { /* best-effort */ }
+                    }
                     return surfaceProfileControllerErrors({res, msg, err: cleanupErr});
                 }
             }

--- a/components/centraldashboard/app/api_workgroup_test.ts
+++ b/components/centraldashboard/app/api_workgroup_test.ts
@@ -518,14 +518,39 @@ describe('Workgroup API', () => {
                 roleRef: {kind: 'ClusterRole', name: 'view'},
             }, jasmine.anything());
         });
+        it('Should error with cleanup message when old binding delete fails during role change', async () => {
+            buildApi(existingContributors);
+            // viewer@example.com is currently a viewer — upgrade to contributor
+            // createBinding succeeds, but deleteBinding (cleanup of old role) fails
+            mockProfilesService.deleteBinding.and.rejectWith({
+                response: {statusCode: 500, statusMessage: 'Internal Server Error'},
+            });
+            const response = await sendTestRequest(
+                `http://localhost:${port}/api/workgroup/add-contributor/apverma`,
+                headers, 500, 'post', {contributor: 'viewer@example.com'},
+            );
+            expect(response.error).toContain('Role updated but failed to remove existing assignment');
+            expect(response.error).toContain('viewer@example.com');
+            // new binding was created before the failed cleanup
+            expect(mockProfilesService.createBinding).toHaveBeenCalledWith({
+                user: {kind: 'User', name: 'viewer@example.com'},
+                referredNamespace: 'apverma',
+                roleRef: {kind: 'ClusterRole', name: 'edit'},
+            }, jasmine.anything());
+            expect(mockProfilesService.deleteBinding).toHaveBeenCalledWith({
+                user: {kind: 'User', name: 'viewer@example.com'},
+                referredNamespace: 'apverma',
+                roleRef: {kind: 'ClusterRole', name: 'view'},
+            }, jasmine.anything());
+        });
         it('Should error when removing a user not in the namespace', async () => {
             const response = await sendTestRequest(url('remove'), {...headers, 'Transfer-Encoding': 'chunked'}, 400, 'delete', {
                 contributor: 'unknown@google.com',
             });
-            expect(response).toEqual({error: `unknown@google.com is not a contributor or viewer of apverma`});
+            expect(response).toEqual({error: `unknown@google.com is not a contributor of apverma`});
             expect(mockProfilesService.deleteBinding).not.toHaveBeenCalled();
         });
-        it('Should successfully remove a contributor, resolving role from existing bindings', async () => {
+        it('Should successfully remove a contributor', async () => {
             buildApi(existingContributors);
             const response = await sendTestRequest(url('remove'), {...headers, 'Transfer-Encoding': 'chunked'}, 200, 'delete', requestBody);
             expect(response).toEqual(existingContributors);
@@ -536,9 +561,11 @@ describe('Workgroup API', () => {
                 roleRef: {kind: 'ClusterRole', name: 'edit'},
             }, jasmine.anything());
         });
-        it('Should successfully remove a viewer, resolving role from existing bindings', async () => {
+        it('Should successfully remove a viewer', async () => {
             buildApi(existingContributors);
-            const response = await sendTestRequest(url('remove'), {...headers, 'Transfer-Encoding': 'chunked'}, 200, 'delete', {
+            const removeViewerUrl =
+                `http://localhost:${port}/api/workgroup/remove-viewer/apverma`;
+            const response = await sendTestRequest(removeViewerUrl, {...headers, 'Transfer-Encoding': 'chunked'}, 200, 'delete', {
                 contributor: 'viewer@example.com',
             });
             expect(response).toEqual(existingContributors);

--- a/components/centraldashboard/app/api_workgroup_test.ts
+++ b/components/centraldashboard/app/api_workgroup_test.ts
@@ -396,11 +396,15 @@ describe('Workgroup API', () => {
             'content-type': 'application/json',
             [header.goog]: `${prefix.goog}test@testdomain.com`,
         };
+        const mockContributors = [
+            {user: 'apverma@google.com', role: 'contributor'},
+            {user: 'viewer@example.com', role: 'viewer'},
+        ];
 
         beforeEach(() => {
             mockProfilesService = jasmine.createSpyObj<DefaultApi>(['createBinding', 'deleteBinding']);
             const api = newAPI();
-            api.getContributors = async () => ['test'];
+            api.getContributors = async () => mockContributors;
 
             testApp = express();
             testApp.use(express.json());
@@ -437,9 +441,17 @@ describe('Workgroup API', () => {
             expect(response).toEqual({error: `Contributor doesn't look like a valid email address`});
             expect(mockProfilesService.createBinding).not.toHaveBeenCalled();
         });
-        it('Should successfully add a contributor', async () => {
+        it('Should error on invalid role', async () => {
+            const response = await sendTestRequest(url('add'), headers, 400, 'post', {
+                ...requestBody,
+                role: 'owner',
+            });
+            expect(response).toEqual({error: `Invalid role: must be 'contributor' or 'viewer'`});
+            expect(mockProfilesService.createBinding).not.toHaveBeenCalled();
+        });
+        it('Should successfully add a contributor with default edit role', async () => {
             const response = await sendTestRequest(url('add'), headers, 200, 'post', requestBody);
-            expect(response).toEqual(['test']);
+            expect(response).toEqual(mockContributors);
             expect(mockProfilesService.createBinding).toHaveBeenCalledWith({
                 user: {
                     kind: 'User',
@@ -453,9 +465,35 @@ describe('Workgroup API', () => {
             }, jasmine.anything());
             expect(mockProfilesService.deleteBinding).not.toHaveBeenCalled();
         });
-        it('Should successfully remove a contributor', async () => {
+        it('Should successfully add a viewer', async () => {
+            const response = await sendTestRequest(url('add'), headers, 200, 'post', {
+                ...requestBody,
+                role: 'viewer',
+            });
+            expect(response).toEqual(mockContributors);
+            expect(mockProfilesService.createBinding).toHaveBeenCalledWith({
+                user: {
+                    kind: 'User',
+                    name: 'apverma@google.com',
+                },
+                referredNamespace: 'apverma',
+                roleRef: {
+                    kind: 'ClusterRole',
+                    name: 'view',
+                }
+            }, jasmine.anything());
+            expect(mockProfilesService.deleteBinding).not.toHaveBeenCalled();
+        });
+        it('Should error when removing a user not in the namespace', async () => {
+            const response = await sendTestRequest(url('remove'), {...headers, 'Transfer-Encoding': 'chunked'}, 400, 'delete', {
+                contributor: 'unknown@google.com',
+            });
+            expect(response).toEqual({error: `unknown@google.com is not a contributor or viewer of apverma`});
+            expect(mockProfilesService.deleteBinding).not.toHaveBeenCalled();
+        });
+        it('Should successfully remove a contributor, resolving role from existing bindings', async () => {
             const response = await sendTestRequest(url('remove'), {...headers, 'Transfer-Encoding': 'chunked'}, 200, 'delete', requestBody);
-            expect(response).toEqual(['test']);
+            expect(response).toEqual(mockContributors);
             expect(mockProfilesService.createBinding).not.toHaveBeenCalled();
             expect(mockProfilesService.deleteBinding).toHaveBeenCalledWith({
                 user: {
@@ -466,6 +504,24 @@ describe('Workgroup API', () => {
                 roleRef: {
                     kind: 'ClusterRole',
                     name: 'edit',
+                }
+            }, jasmine.anything());
+        });
+        it('Should successfully remove a viewer, resolving role from existing bindings', async () => {
+            const response = await sendTestRequest(url('remove'), {...headers, 'Transfer-Encoding': 'chunked'}, 200, 'delete', {
+                contributor: 'viewer@example.com',
+            });
+            expect(response).toEqual(mockContributors);
+            expect(mockProfilesService.createBinding).not.toHaveBeenCalled();
+            expect(mockProfilesService.deleteBinding).toHaveBeenCalledWith({
+                user: {
+                    kind: 'User',
+                    name: 'viewer@example.com',
+                },
+                referredNamespace: 'apverma',
+                roleRef: {
+                    kind: 'ClusterRole',
+                    name: 'view',
                 }
             }, jasmine.anything());
         });

--- a/components/centraldashboard/app/api_workgroup_test.ts
+++ b/components/centraldashboard/app/api_workgroup_test.ts
@@ -396,16 +396,15 @@ describe('Workgroup API', () => {
             'content-type': 'application/json',
             [header.goog]: `${prefix.goog}test@testdomain.com`,
         };
-        const mockContributors = [
+        const existingContributors = [
             {user: 'apverma@google.com', role: 'contributor'},
             {user: 'viewer@example.com', role: 'viewer'},
         ];
 
-        beforeEach(() => {
+        const buildApi = (contributors = []) => {
             mockProfilesService = jasmine.createSpyObj<DefaultApi>(['createBinding', 'deleteBinding']);
             const api = newAPI();
-            api.getContributors = async () => mockContributors;
-
+            api.getContributors = async () => contributors;
             testApp = express();
             testApp.use(express.json());
             testApp.use(attachUserGCPMiddleware);
@@ -416,6 +415,10 @@ describe('Workgroup API', () => {
                     'Unable to determine system-assigned port for test API server');
             }
             port = addressInfo.port;
+        };
+
+        beforeEach(() => {
+            buildApi();
             url = (type: RouteTypes) =>
                 `http://localhost:${port}/api/workgroup/${type}-contributor/apverma`;
         });
@@ -449,40 +452,83 @@ describe('Workgroup API', () => {
             expect(response).toEqual({error: `Invalid role: must be 'contributor' or 'viewer'`});
             expect(mockProfilesService.createBinding).not.toHaveBeenCalled();
         });
-        it('Should successfully add a contributor with default edit role', async () => {
+        it('Should successfully add a new contributor with default edit role', async () => {
             const response = await sendTestRequest(url('add'), headers, 200, 'post', requestBody);
-            expect(response).toEqual(mockContributors);
+            expect(response).toEqual([]);
             expect(mockProfilesService.createBinding).toHaveBeenCalledWith({
-                user: {
-                    kind: 'User',
-                    name: 'apverma@google.com',
-                },
+                user: {kind: 'User', name: 'apverma@google.com'},
                 referredNamespace: 'apverma',
-                roleRef: {
-                    kind: 'ClusterRole',
-                    name: 'edit',
-                }
+                roleRef: {kind: 'ClusterRole', name: 'edit'},
             }, jasmine.anything());
             expect(mockProfilesService.deleteBinding).not.toHaveBeenCalled();
         });
-        it('Should successfully add a viewer', async () => {
+        it('Should successfully add a new viewer', async () => {
             const response = await sendTestRequest(url('add'), headers, 200, 'post', {
                 ...requestBody,
                 role: 'viewer',
             });
-            expect(response).toEqual(mockContributors);
+            expect(response).toEqual([]);
             expect(mockProfilesService.createBinding).toHaveBeenCalledWith({
-                user: {
-                    kind: 'User',
-                    name: 'apverma@google.com',
-                },
+                user: {kind: 'User', name: 'apverma@google.com'},
                 referredNamespace: 'apverma',
-                roleRef: {
-                    kind: 'ClusterRole',
-                    name: 'view',
-                }
+                roleRef: {kind: 'ClusterRole', name: 'view'},
             }, jasmine.anything());
             expect(mockProfilesService.deleteBinding).not.toHaveBeenCalled();
+        });
+        it('Should bubble kfam error when adding a user with the same role they already have', async () => {
+            buildApi(existingContributors);
+            url = (type: RouteTypes) =>
+                `http://localhost:${port}/api/workgroup/${type}-contributor/apverma`;
+            mockProfilesService.createBinding.and.rejectWith({
+                response: {statusCode: 409, statusMessage: 'Conflict'},
+                body: 'rolebindings.rbac.authorization.k8s.io "user-apverma-clusterrole-edit" already exists',
+            });
+            const response = await sendTestRequest(url('add'), headers, 409, 'post', requestBody);
+            expect(mockProfilesService.deleteBinding).not.toHaveBeenCalled();
+            expect(mockProfilesService.createBinding).toHaveBeenCalled();
+            expect(response.error).toContain('already exists');
+        });
+        it('Should remove old binding and create new one when upgrading role', async () => {
+            buildApi(existingContributors);
+            url = (type: RouteTypes) =>
+                `http://localhost:${port}/api/workgroup/${type}-contributor/apverma`;
+            // viewer@example.com is currently a viewer — upgrade to contributor
+            const response = await sendTestRequest(url('add'), headers, 200, 'post', {
+                contributor: 'viewer@example.com',
+                role: 'contributor',
+            });
+            expect(response).toEqual(existingContributors);
+            expect(mockProfilesService.deleteBinding).toHaveBeenCalledWith({
+                user: {kind: 'User', name: 'viewer@example.com'},
+                referredNamespace: 'apverma',
+                roleRef: {kind: 'ClusterRole', name: 'view'},
+            }, jasmine.anything());
+            expect(mockProfilesService.createBinding).toHaveBeenCalledWith({
+                user: {kind: 'User', name: 'viewer@example.com'},
+                referredNamespace: 'apverma',
+                roleRef: {kind: 'ClusterRole', name: 'edit'},
+            }, jasmine.anything());
+        });
+        it('Should remove old binding and create new one when downgrading role', async () => {
+            buildApi(existingContributors);
+            url = (type: RouteTypes) =>
+                `http://localhost:${port}/api/workgroup/${type}-contributor/apverma`;
+            // apverma@google.com is currently a contributor — downgrade to viewer
+            const response = await sendTestRequest(url('add'), headers, 200, 'post', {
+                ...requestBody,
+                role: 'viewer',
+            });
+            expect(response).toEqual(existingContributors);
+            expect(mockProfilesService.deleteBinding).toHaveBeenCalledWith({
+                user: {kind: 'User', name: 'apverma@google.com'},
+                referredNamespace: 'apverma',
+                roleRef: {kind: 'ClusterRole', name: 'edit'},
+            }, jasmine.anything());
+            expect(mockProfilesService.createBinding).toHaveBeenCalledWith({
+                user: {kind: 'User', name: 'apverma@google.com'},
+                referredNamespace: 'apverma',
+                roleRef: {kind: 'ClusterRole', name: 'view'},
+            }, jasmine.anything());
         });
         it('Should error when removing a user not in the namespace', async () => {
             const response = await sendTestRequest(url('remove'), {...headers, 'Transfer-Encoding': 'chunked'}, 400, 'delete', {
@@ -492,37 +538,31 @@ describe('Workgroup API', () => {
             expect(mockProfilesService.deleteBinding).not.toHaveBeenCalled();
         });
         it('Should successfully remove a contributor, resolving role from existing bindings', async () => {
+            buildApi(existingContributors);
+            url = (type: RouteTypes) =>
+                `http://localhost:${port}/api/workgroup/${type}-contributor/apverma`;
             const response = await sendTestRequest(url('remove'), {...headers, 'Transfer-Encoding': 'chunked'}, 200, 'delete', requestBody);
-            expect(response).toEqual(mockContributors);
+            expect(response).toEqual(existingContributors);
             expect(mockProfilesService.createBinding).not.toHaveBeenCalled();
             expect(mockProfilesService.deleteBinding).toHaveBeenCalledWith({
-                user: {
-                    kind: 'User',
-                    name: 'apverma@google.com',
-                },
+                user: {kind: 'User', name: 'apverma@google.com'},
                 referredNamespace: 'apverma',
-                roleRef: {
-                    kind: 'ClusterRole',
-                    name: 'edit',
-                }
+                roleRef: {kind: 'ClusterRole', name: 'edit'},
             }, jasmine.anything());
         });
         it('Should successfully remove a viewer, resolving role from existing bindings', async () => {
+            buildApi(existingContributors);
+            url = (type: RouteTypes) =>
+                `http://localhost:${port}/api/workgroup/${type}-contributor/apverma`;
             const response = await sendTestRequest(url('remove'), {...headers, 'Transfer-Encoding': 'chunked'}, 200, 'delete', {
                 contributor: 'viewer@example.com',
             });
-            expect(response).toEqual(mockContributors);
+            expect(response).toEqual(existingContributors);
             expect(mockProfilesService.createBinding).not.toHaveBeenCalled();
             expect(mockProfilesService.deleteBinding).toHaveBeenCalledWith({
-                user: {
-                    kind: 'User',
-                    name: 'viewer@example.com',
-                },
+                user: {kind: 'User', name: 'viewer@example.com'},
                 referredNamespace: 'apverma',
-                roleRef: {
-                    kind: 'ClusterRole',
-                    name: 'view',
-                }
+                roleRef: {kind: 'ClusterRole', name: 'view'},
             }, jasmine.anything());
         });
     });

--- a/components/centraldashboard/app/api_workgroup_test.ts
+++ b/components/centraldashboard/app/api_workgroup_test.ts
@@ -389,7 +389,7 @@ describe('Workgroup API', () => {
         });
     });
     describe('Add / Remove Contributor', () => {
-        type RouteTypes = 'add' | 'remove';
+        type RouteTypes = 'add' | 'add-viewer' | 'remove';
         let url: (type: RouteTypes) => string;
         const requestBody = {contributor: 'apverma@google.com'};
         const headers = {
@@ -428,11 +428,12 @@ describe('Workgroup API', () => {
             expect(mockProfilesService.createBinding).not.toHaveBeenCalled();
         });
         it('Should error on missing contributor', async () => {
-            const [rAdd, rRemove] = await Promise.all([
+            const [rAdd, rViewer, rRemove] = await Promise.all([
                 sendTestRequest(url('add'), headers, 400, 'post'),
+                sendTestRequest(`http://localhost:${port}/api/workgroup/add-viewer/apverma`, headers, 400, 'post'),
                 sendTestRequest(url('remove'), headers, 400, 'delete'),
             ]);
-            [rAdd, rRemove].forEach(response => {
+            [rAdd, rViewer, rRemove].forEach(response => {
                 expect(response).toEqual({error: `Missing contributor field.`});
             });
             expect(mockProfilesService.createBinding).not.toHaveBeenCalled();
@@ -444,15 +445,7 @@ describe('Workgroup API', () => {
             expect(response).toEqual({error: `Contributor doesn't look like a valid email address`});
             expect(mockProfilesService.createBinding).not.toHaveBeenCalled();
         });
-        it('Should error on invalid role', async () => {
-            const response = await sendTestRequest(url('add'), headers, 400, 'post', {
-                ...requestBody,
-                role: 'owner',
-            });
-            expect(response).toEqual({error: `Invalid role: must be 'contributor' or 'viewer'`});
-            expect(mockProfilesService.createBinding).not.toHaveBeenCalled();
-        });
-        it('Should successfully add a new contributor with default edit role', async () => {
+        it('Should successfully add a new contributor via add-contributor endpoint', async () => {
             const response = await sendTestRequest(url('add'), headers, 200, 'post', requestBody);
             expect(response).toEqual([]);
             expect(mockProfilesService.createBinding).toHaveBeenCalledWith({
@@ -462,11 +455,9 @@ describe('Workgroup API', () => {
             }, jasmine.anything());
             expect(mockProfilesService.deleteBinding).not.toHaveBeenCalled();
         });
-        it('Should successfully add a new viewer', async () => {
-            const response = await sendTestRequest(url('add'), headers, 200, 'post', {
-                ...requestBody,
-                role: 'viewer',
-            });
+        it('Should successfully add a new viewer via add-viewer endpoint', async () => {
+            const viewerUrl = `http://localhost:${port}/api/workgroup/add-viewer/apverma`;
+            const response = await sendTestRequest(viewerUrl, headers, 200, 'post', requestBody);
             expect(response).toEqual([]);
             expect(mockProfilesService.createBinding).toHaveBeenCalledWith({
                 user: {kind: 'User', name: 'apverma@google.com'},
@@ -477,26 +468,25 @@ describe('Workgroup API', () => {
         });
         it('Should bubble kfam error when adding a user with the same role they already have', async () => {
             buildApi(existingContributors);
-            url = (type: RouteTypes) =>
-                `http://localhost:${port}/api/workgroup/${type}-contributor/apverma`;
             mockProfilesService.createBinding.and.rejectWith({
                 response: {statusCode: 409, statusMessage: 'Conflict'},
                 body: 'rolebindings.rbac.authorization.k8s.io "user-apverma-clusterrole-edit" already exists',
             });
-            const response = await sendTestRequest(url('add'), headers, 409, 'post', requestBody);
+            const response = await sendTestRequest(
+                `http://localhost:${port}/api/workgroup/add-contributor/apverma`,
+                headers, 409, 'post', requestBody,
+            );
             expect(mockProfilesService.deleteBinding).not.toHaveBeenCalled();
             expect(mockProfilesService.createBinding).toHaveBeenCalled();
             expect(response.error).toContain('already exists');
         });
         it('Should remove old binding and create new one when upgrading role', async () => {
             buildApi(existingContributors);
-            url = (type: RouteTypes) =>
-                `http://localhost:${port}/api/workgroup/${type}-contributor/apverma`;
             // viewer@example.com is currently a viewer — upgrade to contributor
-            const response = await sendTestRequest(url('add'), headers, 200, 'post', {
-                contributor: 'viewer@example.com',
-                role: 'contributor',
-            });
+            const response = await sendTestRequest(
+                `http://localhost:${port}/api/workgroup/add-contributor/apverma`,
+                headers, 200, 'post', {contributor: 'viewer@example.com'},
+            );
             expect(response).toEqual(existingContributors);
             expect(mockProfilesService.deleteBinding).toHaveBeenCalledWith({
                 user: {kind: 'User', name: 'viewer@example.com'},
@@ -511,13 +501,11 @@ describe('Workgroup API', () => {
         });
         it('Should remove old binding and create new one when downgrading role', async () => {
             buildApi(existingContributors);
-            url = (type: RouteTypes) =>
-                `http://localhost:${port}/api/workgroup/${type}-contributor/apverma`;
             // apverma@google.com is currently a contributor — downgrade to viewer
-            const response = await sendTestRequest(url('add'), headers, 200, 'post', {
-                ...requestBody,
-                role: 'viewer',
-            });
+            const response = await sendTestRequest(
+                `http://localhost:${port}/api/workgroup/add-viewer/apverma`,
+                headers, 200, 'post', requestBody,
+            );
             expect(response).toEqual(existingContributors);
             expect(mockProfilesService.deleteBinding).toHaveBeenCalledWith({
                 user: {kind: 'User', name: 'apverma@google.com'},
@@ -539,8 +527,6 @@ describe('Workgroup API', () => {
         });
         it('Should successfully remove a contributor, resolving role from existing bindings', async () => {
             buildApi(existingContributors);
-            url = (type: RouteTypes) =>
-                `http://localhost:${port}/api/workgroup/${type}-contributor/apverma`;
             const response = await sendTestRequest(url('remove'), {...headers, 'Transfer-Encoding': 'chunked'}, 200, 'delete', requestBody);
             expect(response).toEqual(existingContributors);
             expect(mockProfilesService.createBinding).not.toHaveBeenCalled();
@@ -552,8 +538,6 @@ describe('Workgroup API', () => {
         });
         it('Should successfully remove a viewer, resolving role from existing bindings', async () => {
             buildApi(existingContributors);
-            url = (type: RouteTypes) =>
-                `http://localhost:${port}/api/workgroup/${type}-contributor/apverma`;
             const response = await sendTestRequest(url('remove'), {...headers, 'Transfer-Encoding': 'chunked'}, 200, 'delete', {
                 contributor: 'viewer@example.com',
             });

--- a/components/centraldashboard/app/api_workgroup_test.ts
+++ b/components/centraldashboard/app/api_workgroup_test.ts
@@ -518,7 +518,7 @@ describe('Workgroup API', () => {
                 roleRef: {kind: 'ClusterRole', name: 'view'},
             }, jasmine.anything());
         });
-        it('Should error with cleanup message when old binding delete fails during role change', async () => {
+        it('Should error with manual cleanup message when old binding delete and rollback both fail', async () => {
             buildApi(existingContributors);
             // viewer@example.com is currently a viewer — upgrade to contributor
             // createBinding succeeds, but deleteBinding (cleanup of old role) fails
@@ -530,6 +530,7 @@ describe('Workgroup API', () => {
                 headers, 500, 'post', {contributor: 'viewer@example.com'},
             );
             expect(response.error).toContain('Role updated but failed to remove existing assignment');
+            expect(response.error).toContain('Manual cleanup required');
             expect(response.error).toContain('viewer@example.com');
             // new binding was created before the failed cleanup
             expect(mockProfilesService.createBinding).toHaveBeenCalledWith({
@@ -539,6 +540,30 @@ describe('Workgroup API', () => {
             }, jasmine.anything());
             expect(mockProfilesService.deleteBinding).toHaveBeenCalledWith({
                 user: {kind: 'User', name: 'viewer@example.com'},
+                referredNamespace: 'apverma',
+                roleRef: {kind: 'ClusterRole', name: 'view'},
+            }, jasmine.anything());
+        });
+        it('Should roll back new binding when old binding delete fails during role change', async () => {
+            buildApi(existingContributors);
+            // apverma@google.com is currently a contributor — downgrade to viewer
+            // cleanup of old contributor binding fails; rollback of new viewer binding succeeds
+            let calls = 0;
+            mockProfilesService.deleteBinding.and.callFake(() => {
+                calls++;
+                // first call: cleanup of old binding fails; second call: rollback succeeds
+                return calls === 1
+                    ? Promise.reject({response: {statusCode: 500, statusMessage: 'Internal Server Error'}})
+                    : Promise.resolve();
+            });
+            const response = await sendTestRequest(
+                `http://localhost:${port}/api/workgroup/add-viewer/apverma`,
+                headers, 500, 'post', requestBody,
+            );
+            expect(response.error).toContain('Role change was not applied');
+            expect(mockProfilesService.deleteBinding).toHaveBeenCalledTimes(2);
+            expect(mockProfilesService.deleteBinding).toHaveBeenCalledWith({
+                user: {kind: 'User', name: 'apverma@google.com'},
                 referredNamespace: 'apverma',
                 roleRef: {kind: 'ClusterRole', name: 'view'},
             }, jasmine.anything());

--- a/components/centraldashboard/app/api_workgroup_test.ts
+++ b/components/centraldashboard/app/api_workgroup_test.ts
@@ -466,19 +466,62 @@ describe('Workgroup API', () => {
             }, jasmine.anything());
             expect(mockProfilesService.deleteBinding).not.toHaveBeenCalled();
         });
-        it('Should bubble kfam error when adding a user with the same role they already have', async () => {
+        it('Should keep an existing requested role without recreating it', async () => {
             buildApi(existingContributors);
-            mockProfilesService.createBinding.and.rejectWith({
-                response: {statusCode: 409, statusMessage: 'Conflict'},
-                body: 'rolebindings.rbac.authorization.k8s.io "user-apverma-clusterrole-edit" already exists',
-            });
             const response = await sendTestRequest(
                 `http://localhost:${port}/api/workgroup/add-contributor/apverma`,
-                headers, 409, 'post', requestBody,
+                headers, 200, 'post', requestBody,
             );
             expect(mockProfilesService.deleteBinding).not.toHaveBeenCalled();
-            expect(mockProfilesService.createBinding).toHaveBeenCalled();
-            expect(response.error).toContain('already exists');
+            expect(mockProfilesService.createBinding).not.toHaveBeenCalled();
+            expect(response).toEqual(existingContributors);
+        });
+        ['contributor', 'viewer'].forEach((requestedRole) => {
+            const oppositeRole = requestedRole === 'contributor' ? 'viewer' : 'contributor';
+            [false, true].forEach((reverseOrder) => {
+                it(`Should reconcile both roles to ${requestedRole} with reverse order ${reverseOrder}`, async () => {
+                    const contributors = [requestedRole, oppositeRole].map((role) => ({
+                        user: requestBody.contributor, role,
+                    }));
+                    buildApi(reverseOrder ? contributors.reverse() : contributors);
+                    mockProfilesService.deleteBinding.and.callFake(() => {
+                        contributors.splice(contributors.findIndex((binding) => binding.role === oppositeRole), 1);
+                        return Promise.resolve();
+                    });
+                    const response = await sendTestRequest(
+                        `http://localhost:${port}/api/workgroup/add-${requestedRole}/apverma`,
+                        headers, 200, 'post', requestBody,
+                    );
+                    expect(response).toEqual([{user: requestBody.contributor, role: requestedRole}]);
+                    expect(mockProfilesService.createBinding).not.toHaveBeenCalled();
+                    expect(mockProfilesService.deleteBinding).toHaveBeenCalledTimes(1);
+                    expect(mockProfilesService.deleteBinding).toHaveBeenCalledWith({
+                        user: {kind: 'User', name: requestBody.contributor},
+                        referredNamespace: 'apverma',
+                        roleRef: {kind: 'ClusterRole', name: oppositeRole === 'viewer' ? 'view' : 'edit'},
+                    }, jasmine.anything());
+                });
+            });
+            it(`Should preserve pre-existing ${requestedRole} when opposite role cleanup fails`, async () => {
+                buildApi([requestedRole, oppositeRole].map((role) => ({
+                    user: requestBody.contributor, role,
+                })));
+                mockProfilesService.deleteBinding.and.rejectWith({
+                    response: {statusCode: 500, statusMessage: 'Internal Server Error'},
+                });
+                const response = await sendTestRequest(
+                    `http://localhost:${port}/api/workgroup/add-${requestedRole}/apverma`,
+                    headers, 500, 'post', requestBody,
+                );
+                expect(response.error).toContain('Manual cleanup required');
+                expect(mockProfilesService.createBinding).not.toHaveBeenCalled();
+                expect(mockProfilesService.deleteBinding).toHaveBeenCalledTimes(1);
+                expect(mockProfilesService.deleteBinding).toHaveBeenCalledWith({
+                    user: {kind: 'User', name: requestBody.contributor},
+                    referredNamespace: 'apverma',
+                    roleRef: {kind: 'ClusterRole', name: oppositeRole === 'viewer' ? 'view' : 'edit'},
+                }, jasmine.anything());
+            });
         });
         it('Should remove old binding and create new one when upgrading role', async () => {
             buildApi(existingContributors);

--- a/components/centraldashboard/app/api_workgroup_test.ts
+++ b/components/centraldashboard/app/api_workgroup_test.ts
@@ -561,12 +561,11 @@ describe('Workgroup API', () => {
                 roleRef: {kind: 'ClusterRole', name: 'view'},
             }, jasmine.anything());
         });
-        it('Should error with manual cleanup message when old binding delete and rollback both fail', async () => {
+        it('Should retain the new binding and report cleanup details when old binding delete fails', async () => {
             buildApi(existingContributors);
-            // viewer@example.com is currently a viewer — upgrade to contributor
-            // createBinding succeeds, but deleteBinding (cleanup of old role) fails
             mockProfilesService.deleteBinding.and.rejectWith({
                 response: {statusCode: 500, statusMessage: 'Internal Server Error'},
+                body: 'failed to delete authorization policy',
             });
             const response = await sendTestRequest(
                 `http://localhost:${port}/api/workgroup/add-contributor/apverma`,
@@ -575,7 +574,7 @@ describe('Workgroup API', () => {
             expect(response.error).toContain('Role updated but failed to remove existing assignment');
             expect(response.error).toContain('Manual cleanup required');
             expect(response.error).toContain('viewer@example.com');
-            // new binding was created before the failed cleanup
+            expect(response.error).toContain('failed to delete authorization policy');
             expect(mockProfilesService.createBinding).toHaveBeenCalledWith({
                 user: {kind: 'User', name: 'viewer@example.com'},
                 referredNamespace: 'apverma',
@@ -586,30 +585,7 @@ describe('Workgroup API', () => {
                 referredNamespace: 'apverma',
                 roleRef: {kind: 'ClusterRole', name: 'view'},
             }, jasmine.anything());
-        });
-        it('Should roll back new binding when old binding delete fails during role change', async () => {
-            buildApi(existingContributors);
-            // apverma@google.com is currently a contributor — downgrade to viewer
-            // cleanup of old contributor binding fails; rollback of new viewer binding succeeds
-            let calls = 0;
-            mockProfilesService.deleteBinding.and.callFake(() => {
-                calls++;
-                // first call: cleanup of old binding fails; second call: rollback succeeds
-                return calls === 1
-                    ? Promise.reject({response: {statusCode: 500, statusMessage: 'Internal Server Error'}})
-                    : Promise.resolve();
-            });
-            const response = await sendTestRequest(
-                `http://localhost:${port}/api/workgroup/add-viewer/apverma`,
-                headers, 500, 'post', requestBody,
-            );
-            expect(response.error).toContain('Role change was not applied');
-            expect(mockProfilesService.deleteBinding).toHaveBeenCalledTimes(2);
-            expect(mockProfilesService.deleteBinding).toHaveBeenCalledWith({
-                user: {kind: 'User', name: 'apverma@google.com'},
-                referredNamespace: 'apverma',
-                roleRef: {kind: 'ClusterRole', name: 'view'},
-            }, jasmine.anything());
+            expect(mockProfilesService.deleteBinding).toHaveBeenCalledTimes(1);
         });
         it('Should error when removing a user not in the namespace', async () => {
             const response = await sendTestRequest(url('remove'), {...headers, 'Transfer-Encoding': 'chunked'}, 400, 'delete', {

--- a/components/centraldashboard/public/components/logout-button.js
+++ b/components/centraldashboard/public/components/logout-button.js
@@ -1,4 +1,4 @@
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
 import '@polymer/paper-button/paper-button.js';
 import css from './logout-button.css';
 
@@ -18,7 +18,6 @@ export class LogoutButton extends PolymerElement {
                 </paper-button>
             </a>
         `]);
-        ;
     }
 
     /**

--- a/components/centraldashboard/public/components/logout-button.js
+++ b/components/centraldashboard/public/components/logout-button.js
@@ -1,4 +1,4 @@
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
 import '@polymer/paper-button/paper-button.js';
 import css from './logout-button.css';
 import {templateContent} from './resources/template-utils.js';
@@ -19,7 +19,6 @@ export class LogoutButton extends PolymerElement {
                 </paper-button>
             </a>
         `));
-        ;
     }
 
     /**

--- a/components/centraldashboard/public/components/manage-users-view-contributor.css
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.css
@@ -30,6 +30,9 @@ h2 .icon {
 .content.small {
     max-width: 640px;
 }
+#ContribError {
+    background: #F44336
+}
 .add-row paper-dropdown-menu {
     --paper-input-container-focus-color: var(--accent-color);
     --paper-listbox-background-color: white;

--- a/components/centraldashboard/public/components/manage-users-view-contributor.css
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.css
@@ -30,7 +30,22 @@ h2 .icon {
 .content.small {
     max-width: 640px;
 }
-#ContribError {
-    background: #F44336
+.add-row paper-dropdown-menu {
+    --paper-input-container-focus-color: var(--accent-color);
+    --paper-listbox-background-color: white;
+    --paper-listbox-color: black;
+}
+.add-row {
+    display: flex;
+    align-items: flex-end;
+    gap: .75em;
+    margin-bottom: .5em;
+}
+.add-row md2-input {
+    flex: 1;
+}
+.add-row paper-dropdown-menu[disabled] {
+    opacity: 0.4;
+    pointer-events: none;
 }
 [hidden] {display: none !important}

--- a/components/centraldashboard/public/components/manage-users-view-contributor.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.js
@@ -70,6 +70,10 @@ export class ManageUsersViewContributor extends utilitiesMixin(PolymerElement) {
      * @return {string}
      */
     _isolateErrorFromIronRequest(e) {
+        const status = e.detail.request.status;
+        if (status === 403) {
+            return 'You are not authorized to perform this action.';
+        }
         const bd = e.detail.request.response||{};
         return bd.error || e.detail.error || e.detail;
     }

--- a/components/centraldashboard/public/components/manage-users-view-contributor.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.js
@@ -37,14 +37,21 @@ export class ManageUsersViewContributor extends utilitiesMixin(PolymerElement) {
     }
 
     /**
+     * Computes the add URL based on the selected role.
+     * @param {string} namespace
+     * @param {string} role
+     * @return {string}
+     */
+    _addUrl(namespace, role) {
+        const endpoint = role === 'viewer' ? 'add-viewer' : 'add-contributor';
+        return `/api/workgroup/${endpoint}/${namespace}`;
+    }
+    /**
      * Triggers an API call to create a new Contributor
      */
     addNewContrib() {
         const api = this.$.AddContribAjax;
-        api.body = {
-            contributor: this.newContribEmail,
-            role: this.newContribRole,
-        };
+        api.body = {contributor: this.newContribEmail};
         api.generateRequest();
     }
     /**

--- a/components/centraldashboard/public/components/manage-users-view-contributor.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.js
@@ -3,9 +3,9 @@ import '@polymer/iron-icon/iron-icon.js';
 import '@polymer/iron-icons/iron-icons.js';
 import '@polymer/iron-icons/social-icons.js';
 import '@polymer/paper-toast/paper-toast.js';
-import '@polymer/paper-ripple/paper-ripple.js';
-import '@polymer/paper-item/paper-icon-item.js';
-import '@polymer/paper-icon-button/paper-icon-button.js';
+import '@polymer/paper-dropdown-menu/paper-dropdown-menu.js';
+import '@polymer/paper-listbox/paper-listbox.js';
+import '@polymer/paper-item/paper-item.js';
 
 import {html, PolymerElement} from '@polymer/polymer';
 
@@ -31,25 +31,20 @@ export class ManageUsersViewContributor extends utilitiesMixin(PolymerElement) {
             user: {type: String, value: 'Loading...'},
             ownedNamespace: {type: Object, value: () => ({})},
             newContribEmail: String,
+            newContribRole: {type: String, value: 'contributor'},
             contribError: Object,
-            contributorInputEl: Object,
         };
-    }
-    /**
-     * Main ready method for Polymer Elements.
-     */
-    ready() {
-        super.ready();
-        this.contributorInputEl = this.$.ContribEmail;
     }
 
     /**
      * Triggers an API call to create a new Contributor
      */
     addNewContrib() {
-        // Need to call the api directly here.
         const api = this.$.AddContribAjax;
-        api.body = {contributor: this.newContribEmail};
+        api.body = {
+            contributor: this.newContribEmail,
+            role: this.newContribRole,
+        };
         api.generateRequest();
     }
     /**
@@ -58,7 +53,7 @@ export class ManageUsersViewContributor extends utilitiesMixin(PolymerElement) {
      */
     removeContributor(e) {
         const api = this.$.RemoveContribAjax;
-        api.body = {contributor: e.model.item};
+        api.body = {contributor: e.model.item.user};
         api.generateRequest();
     }
     /**

--- a/components/centraldashboard/public/components/manage-users-view-contributor.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.js
@@ -32,6 +32,7 @@ export class ManageUsersViewContributor extends utilitiesMixin(PolymerElement) {
             ownedNamespace: {type: Object, value: () => ({})},
             newContribEmail: String,
             newContribRole: {type: String, value: 'contributor'},
+            _removingRole: {type: String, value: 'contributor'},
             contribError: Object,
         };
     }
@@ -55,10 +56,22 @@ export class ManageUsersViewContributor extends utilitiesMixin(PolymerElement) {
         api.generateRequest();
     }
     /**
+     * Computes the remove URL based on the role being removed.
+     * @param {string} namespace
+     * @param {string} role
+     * @return {string}
+     */
+    _removeUrl(namespace, role) {
+        const endpoint =
+            role === 'viewer' ? 'remove-viewer' : 'remove-contributor';
+        return `/api/workgroup/${endpoint}/${namespace}`;
+    }
+    /**
      * Triggers an API call to remove a Contributor
      * @param {Event} e
      */
     removeContributor(e) {
+        this._removingRole = e.model.item.role;
         const api = this.$.RemoveContribAjax;
         api.body = {contributor: e.model.item.user};
         api.generateRequest();

--- a/components/centraldashboard/public/components/manage-users-view-contributor.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.js
@@ -33,6 +33,7 @@ export class ManageUsersViewContributor extends utilitiesMixin(PolymerElement) {
             ownedNamespace: {type: Object, value: () => ({})},
             newContribEmail: String,
             newContribRole: {type: String, value: 'contributor'},
+            _removingRole: {type: String, value: 'contributor'},
             contribError: Object,
         };
     }
@@ -56,10 +57,22 @@ export class ManageUsersViewContributor extends utilitiesMixin(PolymerElement) {
         api.generateRequest();
     }
     /**
+     * Computes the remove URL based on the role being removed.
+     * @param {string} namespace
+     * @param {string} role
+     * @return {string}
+     */
+    _removeUrl(namespace, role) {
+        const endpoint =
+            role === 'viewer' ? 'remove-viewer' : 'remove-contributor';
+        return `/api/workgroup/${endpoint}/${namespace}`;
+    }
+    /**
      * Triggers an API call to remove a Contributor
      * @param {Event} e
      */
     removeContributor(e) {
+        this._removingRole = e.model.item.role;
         const api = this.$.RemoveContribAjax;
         api.body = {contributor: e.model.item.user};
         api.generateRequest();

--- a/components/centraldashboard/public/components/manage-users-view-contributor.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.js
@@ -71,6 +71,10 @@ export class ManageUsersViewContributor extends utilitiesMixin(PolymerElement) {
      * @return {string}
      */
     _isolateErrorFromIronRequest(e) {
+        const status = e.detail.request.status;
+        if (status === 403) {
+            return 'You are not authorized to perform this action.';
+        }
         const bd = e.detail.request.response||{};
         return bd.error || e.detail.error || e.detail;
     }

--- a/components/centraldashboard/public/components/manage-users-view-contributor.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.js
@@ -38,14 +38,21 @@ export class ManageUsersViewContributor extends utilitiesMixin(PolymerElement) {
     }
 
     /**
+     * Computes the add URL based on the selected role.
+     * @param {string} namespace
+     * @param {string} role
+     * @return {string}
+     */
+    _addUrl(namespace, role) {
+        const endpoint = role === 'viewer' ? 'add-viewer' : 'add-contributor';
+        return `/api/workgroup/${endpoint}/${namespace}`;
+    }
+    /**
      * Triggers an API call to create a new Contributor
      */
     addNewContrib() {
         const api = this.$.AddContribAjax;
-        api.body = {
-            contributor: this.newContribEmail,
-            role: this.newContribRole,
-        };
+        api.body = {contributor: this.newContribEmail};
         api.generateRequest();
     }
     /**

--- a/components/centraldashboard/public/components/manage-users-view-contributor.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.js
@@ -3,9 +3,9 @@ import '@polymer/iron-icon/iron-icon.js';
 import '@polymer/iron-icons/iron-icons.js';
 import '@polymer/iron-icons/social-icons.js';
 import '@polymer/paper-toast/paper-toast.js';
-import '@polymer/paper-ripple/paper-ripple.js';
-import '@polymer/paper-item/paper-icon-item.js';
-import '@polymer/paper-icon-button/paper-icon-button.js';
+import '@polymer/paper-dropdown-menu/paper-dropdown-menu.js';
+import '@polymer/paper-listbox/paper-listbox.js';
+import '@polymer/paper-item/paper-item.js';
 
 import {html, PolymerElement} from '@polymer/polymer';
 
@@ -32,25 +32,20 @@ export class ManageUsersViewContributor extends utilitiesMixin(PolymerElement) {
             user: {type: String, value: 'Loading...'},
             ownedNamespace: {type: Object, value: () => ({})},
             newContribEmail: String,
+            newContribRole: {type: String, value: 'contributor'},
             contribError: Object,
-            contributorInputEl: Object,
         };
-    }
-    /**
-     * Main ready method for Polymer Elements.
-     */
-    ready() {
-        super.ready();
-        this.contributorInputEl = this.$.ContribEmail;
     }
 
     /**
      * Triggers an API call to create a new Contributor
      */
     addNewContrib() {
-        // Need to call the api directly here.
         const api = this.$.AddContribAjax;
-        api.body = {contributor: this.newContribEmail};
+        api.body = {
+            contributor: this.newContribEmail,
+            role: this.newContribRole,
+        };
         api.generateRequest();
     }
     /**
@@ -59,7 +54,7 @@ export class ManageUsersViewContributor extends utilitiesMixin(PolymerElement) {
      */
     removeContributor(e) {
         const api = this.$.RemoveContribAjax;
-        api.body = {contributor: e.model.item};
+        api.body = {contributor: e.model.item.user};
         api.generateRequest();
     }
     /**

--- a/components/centraldashboard/public/components/manage-users-view-contributor.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.js
@@ -85,10 +85,10 @@ export class ManageUsersViewContributor extends utilitiesMixin(PolymerElement) {
      */
     _isolateErrorFromIronRequest(e) {
         const status = e.detail.request.status;
-        if (status === 403) {
+        const bd = e.detail.request.response || {};
+        if (status === 403 && !bd.error) {
             return 'You are not authorized to perform this action.';
         }
-        const bd = e.detail.request.response||{};
         return bd.error || e.detail.error || e.detail;
     }
     /**

--- a/components/centraldashboard/public/components/manage-users-view-contributor.pug
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.pug
@@ -1,4 +1,4 @@
-iron-ajax#RemoveContribAjax(method='DELETE', url='/api/workgroup/remove-contributor/[[ownedNamespace.namespace]]',
+iron-ajax#RemoveContribAjax(method='DELETE', url='[[_removeUrl(ownedNamespace.namespace, _removingRole)]]',
     on-response='handleContribDelete', on-error='handleContribDelete', handle-as='json', content-type='application/json')
 iron-ajax#AddContribAjax(method='POST', url='[[_addUrl(ownedNamespace.namespace, newContribRole)]]',
     on-response='handleContribCreate', on-error='handleContribCreate', handle-as='json', content-type='application/json')

--- a/components/centraldashboard/public/components/manage-users-view-contributor.pug
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.pug
@@ -1,6 +1,6 @@
 iron-ajax#RemoveContribAjax(method='DELETE', url='/api/workgroup/remove-contributor/[[ownedNamespace.namespace]]',
     on-response='handleContribDelete', on-error='handleContribDelete', handle-as='json', content-type='application/json')
-iron-ajax#AddContribAjax(method='POST', url='/api/workgroup/add-contributor/[[ownedNamespace.namespace]]',
+iron-ajax#AddContribAjax(method='POST', url='[[_addUrl(ownedNamespace.namespace, newContribRole)]]',
     on-response='handleContribCreate', on-error='handleContribCreate', handle-as='json', content-type='application/json')
 iron-ajax#GetContribsAjax(auto='[[!empty(ownedNamespace)]]', url='/api/workgroup/get-contributors/[[ownedNamespace.namespace]]',
     last-response='{{contributorList}}', on-error='onContribFetchError', handle-as='json')

--- a/components/centraldashboard/public/components/manage-users-view-contributor.pug
+++ b/components/centraldashboard/public/components/manage-users-view-contributor.pug
@@ -11,10 +11,15 @@ h2
         |
         code [[ownedNamespace.namespace]]
 .content.small
-    md2-input(label='Email Addresses', value='{{newContribEmail}}', on-submit='addNewContrib', placeholder='Add by email address', error$='[[contribCreateError]]')
-        .prefix(slot='prefix')
-            template(is='dom-repeat', items='[[contributorList]]')
-                paper-chip(on-remove='removeContributor') [[item]]
+    .add-row
+        md2-input(label='Email Address', value='{{newContribEmail}}', on-submit='addNewContrib', placeholder='Add by email address', error$='[[contribCreateError]]')
+            .prefix(slot='prefix')
+                template(is='dom-repeat', items='[[contributorList]]')
+                    paper-chip(on-remove='removeContributor') [[item.user]] ([[item.role]])
+        paper-dropdown-menu(label='Role', no-animations, disabled$='[[!newContribEmail]]')
+            paper-listbox(slot='dropdown-content', selected='{{newContribRole}}', attr-for-selected='value')
+                paper-item(value='contributor') Edit
+                paper-item(value='viewer') View
 paper-toast#ContribError(duration=5000)
     | Failed to fetch contributor list for {{ownedNamespace.namespace}}, because:
     strong [[contribError]]

--- a/components/centraldashboard/public/components/manage-users-view-contributor_test.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor_test.js
@@ -17,6 +17,10 @@ const TEMPLATE = `
 `;
 const user = 'test@kubeflow.org';
 const ownedNs = {namespace: 'ns1', role: 'owner'};
+const contribList = [
+    {user: 'foo@kubeflow.org', role: 'contributor'},
+    {user: 'bar@kubeflow.org', role: 'viewer'},
+];
 
 describe('Manage Users View Contributor', () => {
     let manageUsersViewContributor;
@@ -64,15 +68,14 @@ describe('Manage Users View Contributor', () => {
     });
 
     it('Should add contributors correctly', async () => {
-        const contribList = ['foo@kubeflow.org', 'bar@kubeflow.org'];
-        const verificationContribs = ['ap@kubeflow.org'];
+        const updatedList = [{user: 'ap@kubeflow.org', role: 'contributor'}];
         mockIronAjax(
             manageUsersViewContributor.$.GetContribsAjax,
             contribList,
         );
         mockIronAjax(
             manageUsersViewContributor.$.AddContribAjax,
-            verificationContribs,
+            updatedList,
         );
 
         manageUsersViewContributor.user = user;
@@ -89,21 +92,20 @@ describe('Manage Users View Contributor', () => {
 
         expect(manageUsersViewContributor.contributorList)
             .toEqual(
-                verificationContribs,
+                updatedList,
                 'Invalid list of contributors'
             );
     });
 
     it('Should remove contributors correctly', async () => {
-        const contribList = ['foo@kubeflow.org', 'bar@kubeflow.org'];
-        const verificationContribs = ['ap@kubeflow.org'];
+        const updatedList = [{user: 'ap@kubeflow.org', role: 'contributor'}];
         mockIronAjax(
             manageUsersViewContributor.$.GetContribsAjax,
             contribList,
         );
         mockIronAjax(
             manageUsersViewContributor.$.RemoveContribAjax,
-            verificationContribs,
+            updatedList,
         );
 
         manageUsersViewContributor.user = user;
@@ -112,20 +114,19 @@ describe('Manage Users View Contributor', () => {
         flush();
         await yieldForRequests();
 
-        const chip = manageUsersViewContributor.shadowRoot.querySelector('md2-input paper-chip:nth-of-type(1)');
-        chip.fireRemove({});
+        const removeBtn = manageUsersViewContributor.shadowRoot.querySelector('.contrib-row paper-icon-button');
+        removeBtn.click();
 
         await yieldForRequests();
 
         expect(manageUsersViewContributor.contributorList)
             .toEqual(
-                verificationContribs,
+                updatedList,
                 'Invalid list of contributors'
             );
     });
 
     it('UI State should show contribs when namespace available', async () => {
-        const contribList = ['foo@kubeflow.org', 'bar@kubeflow.org'];
         mockIronAjax(
             manageUsersViewContributor.$.GetContribsAjax,
             contribList,
@@ -140,7 +141,6 @@ describe('Manage Users View Contributor', () => {
         expect(manageUsersViewContributor.shadowRoot.querySelector('h2 > .text').innerText)
             .toBe('Contributors for - ns1');
 
-        // View prop expectations
         expect(manageUsersViewContributor.contributorList)
             .toEqual(
                 contribList,

--- a/components/centraldashboard/public/components/manage-users-view-contributor_test.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor_test.js
@@ -67,6 +67,20 @@ describe('Manage Users View Contributor', () => {
             .toBe('Failed for test');
     });
 
+    it('Should show friendly message on 403 from add', () => {
+        // Simulate a 403 iron-ajax error event directly
+        const fakeEvent = {
+            detail: {
+                error: 'The request failed with status code: 403',
+                request: {status: 403, response: null},
+            },
+        };
+        manageUsersViewContributor.handleContribCreate(fakeEvent);
+
+        expect(manageUsersViewContributor.contribCreateError)
+            .toBe('You are not authorized to perform this action.');
+    });
+
     it('Should add contributors correctly', async () => {
         const updatedList = [{user: 'ap@kubeflow.org', role: 'contributor'}];
         mockIronAjax(
@@ -114,8 +128,9 @@ describe('Manage Users View Contributor', () => {
         flush();
         await yieldForRequests();
 
-        const removeBtn = manageUsersViewContributor.shadowRoot.querySelector('.contrib-row paper-icon-button');
-        removeBtn.click();
+        manageUsersViewContributor.removeContributor(
+            {model: {item: contribList[0]}}
+        );
 
         await yieldForRequests();
 

--- a/components/centraldashboard/public/components/manage-users-view-contributor_test.js
+++ b/components/centraldashboard/public/components/manage-users-view-contributor_test.js
@@ -67,18 +67,33 @@ describe('Manage Users View Contributor', () => {
             .toBe('Failed for test');
     });
 
-    it('Should show friendly message on 403 from add', () => {
-        // Simulate a 403 iron-ajax error event directly
-        const fakeEvent = {
-            detail: {
-                error: 'The request failed with status code: 403',
-                request: {status: 403, response: null},
-            },
-        };
-        manageUsersViewContributor.handleContribCreate(fakeEvent);
+    ['handleContribCreate', 'handleContribDelete'].forEach((handler) => {
+        it(`Should show friendly message on body-less 403 from ${handler}`, () => {
+            const fakeEvent = {
+                detail: {
+                    error: 'The request failed with status code: 403',
+                    request: {status: 403, response: null},
+                },
+            };
+            manageUsersViewContributor[handler](fakeEvent);
 
-        expect(manageUsersViewContributor.contribCreateError)
-            .toBe('You are not authorized to perform this action.');
+            expect(manageUsersViewContributor.contribCreateError)
+                .toBe('You are not authorized to perform this action.');
+        });
+
+        it(`Should preserve backend error on 403 from ${handler}`, () => {
+            const backendError = 'RoleBinding operation failed: already exists';
+            const fakeEvent = {
+                detail: {
+                    error: 'The request failed with status code: 403',
+                    request: {status: 403, response: {error: backendError}},
+                },
+            };
+            manageUsersViewContributor[handler](fakeEvent);
+
+            expect(manageUsersViewContributor.contribCreateError)
+                .toBe(backendError);
+        });
     });
 
     it('Should add contributors correctly', async () => {


### PR DESCRIPTION
# Description 
Proposal on handling both "viewers" (binding for `kubeflow-view`) and "editors" (binding for `kubeflow-edit`) as "contributors" in the Kubeflow Central Dashboard. See cluster roles [in the community distribution.](https://github.com/kubeflow/community-distribution/blob/26.03/common/kubeflow-roles/base/cluster-roles.yaml)

## Demo setup
During testing the implementation, the following setup was used:
- `kind` cluster
- oauth2-proxy + dex + keycloak for auth, where keycloak is configured with two users
  - `user@example.com` - cluster admin
  - `user1@example.com`
- 2 _Profiles_
  -  `namespace-1` and `namespace-2`, both owned by `user@example.com`

## Adding contributors
`user@example.com` adding:
1. `user1@example.com` as a "edit" contributor to `namespace-1` --> `RoleBinding` to `kubeflow-edit`
2. `user1@example.com` as a "view" contributor to `namespace-1` --> `RoleBinding` to `kubeflow-view`

The role selection dropdown is placed on the side of the input field, but disabled as long as input is empty.
<img width="718" height="103" alt="Screenshot 2026-07-11 at 16 50 02" src="https://github.com/user-attachments/assets/4c335980-a2fe-4d6a-8d84-3a4ad182d22e" />

When input is no longer empty, the role dropdown is enabled.
<img width="706" height="104" alt="Screenshot 2026-07-11 at 16 50 17" src="https://github.com/user-attachments/assets/8648fb89-42ad-415c-8c27-034efd2341e8" />
<img width="200" height="128" alt="Screenshot 2026-07-11 at 16 50 40" src="https://github.com/user-attachments/assets/168a8e08-fece-43fe-8e5e-5487f4805eea" />

Labels indicating the level of access of a contributor are applied on each contributor chip.
<img width="709" height="185" alt="Screenshot 2026-07-11 at 17 07 01" src="https://github.com/user-attachments/assets/1ce75272-9ff5-40b1-bda6-796527b4e4b8" />


### API endpoints split
`add-contributor` and `add-viewer` are now two separate endpoints in the UI backend. 
LE: same for `remove-contributor` and `remove-viewer` for the same reason as below.

This allows cluster admins to block users from adding `edit` contributors on clusters where security guardrails need to be narrower by e.g. using an Istio `AuthorizationPolicy` such as:
```yaml
apiVersion: security.istio.io/v1
kind: AuthorizationPolicy
metadata:
  name: deny-add-contributor
  namespace: kubeflow
spec:
  selector:
    matchLabels:
      app: centraldashboard
  action: DENY
  rules:
  - to:
    - operation:
        methods: ["POST"]
        paths: ["/api/workgroup/add-contributor/*"]
```
Adding a viewer still works, while adding a contributor gets a 403 from Istio and shows a clear error message:
<img width="652" height="161" alt="Screenshot 2026-07-25 at 12 04 06" src="https://github.com/user-attachments/assets/0c41d74c-da28-4681-9acd-1aada8decc24" />
<img width="702" height="167" alt="Screenshot 2026-07-25 at 12 03 17" src="https://github.com/user-attachments/assets/7233c071-b38c-4fcb-9112-1d60438a9b4d" />
<img width="709" height="161" alt="Screenshot 2026-07-25 at 12 02 11" src="https://github.com/user-attachments/assets/736d2357-8ec6-4710-a3b9-372a9e87c8b8" />

### Open questions
<img width="711" height="180" alt="Screenshot 2026-07-11 at 16 50 48" src="https://github.com/user-attachments/assets/fd9c5463-9d14-41f0-952a-f45b31e8317a" />

**Q:** `user1@example.com` can be added twice, since a rejection only happens when an error bubbles all the way up from `kfam` because a `RoleBinding` name with the same name exists (e.g. _rolebindings.rbac.authorization.k8s.io "user-user1-example-com-clusterrole-edit" already exists._). `user-user1-example-com-clusterrole-edit` and `user-user1-example-com-clusterrole-view` can co-exist just fine as far as the kubelet is concerned, so no error bubbles up to the dashboard. Should we 
    1) accept this,
    2) have kfam reject the action when `user-user1-example-com-clusterrole-*` exists?
    3) have `edit` override `view` (perhaps kfam could do the cleanup), or
    4) have the latest action take precedence (e.g. adding someone with the `view` role takes their `edit` role away and vice-versa)?
**A: Went with option 4).**

# AI Policy Disclosure
See https://www.kubeflow.org/docs/about/ai_policy/.
`claude-sonnet-4.6` was used as a coding assistant, mostly on the frontend - `centraldashboard` - component. The model did NOT run in agentic mode, every generated snippet of code was reviewed and / or modified by the submitter.