### PR TITLE
fix: upgrade VirtualService manifests from v1alpha3 to stable networking.istio.io/v1

### DIFF
--- a/components/centraldashboard-angular/manifests/kustomize/components/istio/virtual-service.yaml
+++ b/components/centraldashboard-angular/manifests/kustomize/components/istio/virtual-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: dashboard-angular

--- a/components/centraldashboard-angular/manifests/kustomize/overlays/istio/kustomization.yaml
+++ b/components/centraldashboard-angular/manifests/kustomize/overlays/istio/kustomization.yaml
@@ -25,7 +25,7 @@ replacements:
           group: networking.istio.io
           kind: VirtualService
           name: dashboard-angular
-          version: v1alpha3
+          version: v1
   - source:
       fieldPath: metadata.namespace
       kind: Service
@@ -41,7 +41,7 @@ replacements:
           group: networking.istio.io
           kind: VirtualService
           name: dashboard-angular
-          version: v1alpha3
+          version: v1
   - source:
       fieldPath: metadata.namespace
       kind: ServiceAccount

--- a/components/centraldashboard-angular/manifests/kustomize/overlays/kserve/kustomization.yaml
+++ b/components/centraldashboard-angular/manifests/kustomize/overlays/kserve/kustomization.yaml
@@ -28,7 +28,7 @@ replacements:
           group: networking.istio.io
           kind: VirtualService
           name: dashboard-angular
-          version: v1alpha3
+          version: v1
   - source:
       fieldPath: metadata.namespace
       kind: Service
@@ -44,7 +44,7 @@ replacements:
           group: networking.istio.io
           kind: VirtualService
           name: dashboard-angular
-          version: v1alpha3
+          version: v1
   - source:
       fieldPath: metadata.namespace
       kind: ServiceAccount

--- a/components/centraldashboard/manifests/kustomize/components/istio/virtual-service.yaml
+++ b/components/centraldashboard/manifests/kustomize/components/istio/virtual-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: dashboard

--- a/components/centraldashboard/manifests/kustomize/overlays/istio/kustomization.yaml
+++ b/components/centraldashboard/manifests/kustomize/overlays/istio/kustomization.yaml
@@ -25,7 +25,7 @@ replacements:
           group: networking.istio.io
           kind: VirtualService
           name: dashboard
-          version: v1alpha3
+          version: v1
   - source:
       fieldPath: metadata.namespace
       kind: Service
@@ -41,7 +41,7 @@ replacements:
           group: networking.istio.io
           kind: VirtualService
           name: dashboard
-          version: v1alpha3
+          version: v1
   - source:
       fieldPath: metadata.namespace
       kind: ServiceAccount

--- a/components/centraldashboard/manifests/kustomize/overlays/kserve/kustomization.yaml
+++ b/components/centraldashboard/manifests/kustomize/overlays/kserve/kustomization.yaml
@@ -28,7 +28,7 @@ replacements:
           group: networking.istio.io
           kind: VirtualService
           name: dashboard
-          version: v1alpha3
+          version: v1
   - source:
       fieldPath: metadata.namespace
       kind: Service
@@ -44,7 +44,7 @@ replacements:
           group: networking.istio.io
           kind: VirtualService
           name: dashboard
-          version: v1alpha3
+          version: v1
   - source:
       fieldPath: metadata.namespace
       kind: ServiceAccount

--- a/components/profile-controller/manifests/kustomize/components/istio/virtual-service.yaml
+++ b/components/profile-controller/manifests/kustomize/components/istio/virtual-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: profiles-kfam

--- a/components/profile-controller/manifests/kustomize/overlays/kubeflow/kustomization.yaml
+++ b/components/profile-controller/manifests/kustomize/overlays/kubeflow/kustomization.yaml
@@ -43,7 +43,7 @@ replacements:
           group: networking.istio.io
           kind: VirtualService
           name: profiles-kfam
-          version: v1alpha3
+          version: v1
   - source:
       fieldPath: spec.ports.0.port
       kind: Service
@@ -71,7 +71,7 @@ replacements:
           group: networking.istio.io
           kind: VirtualService
           name: profiles-kfam
-          version: v1alpha3
+          version: v1
   - source:
       fieldPath: metadata.namespace
       kind: ServiceAccount


### PR DESCRIPTION
closes #201

upgrades all VirtualService resources and their kustomize replacement selectors from `networking.istio.io/v1alpha3` to `networking.istio.io/v1`. the VirtualService API has been stable since [Istio 1.22](https://istio.io/latest/news/releases/1.22.x/announcing-1.22/). the spec schema is identical between v1alpha3 and v1 — this is a pure apiVersion promotion with no functional change. the dashboard CI already uses Istio 1.29.1 ([`install_istio.sh`](https://github.com/kubeflow/dashboard/blob/main/testing/gh-actions/install_istio.sh#L5)).

### files changed (8)

**virtual-service.yaml** (3 files — `apiVersion` line):
- `components/centraldashboard/manifests/kustomize/components/istio/virtual-service.yaml`
- `components/centraldashboard-angular/manifests/kustomize/components/istio/virtual-service.yaml`
- `components/profile-controller/manifests/kustomize/components/istio/virtual-service.yaml`

**kustomization.yaml** (5 files — kustomize replacement `select.version` fields):
- `components/centraldashboard/manifests/kustomize/overlays/istio/kustomization.yaml`
- `components/centraldashboard/manifests/kustomize/overlays/kserve/kustomization.yaml`
- `components/centraldashboard-angular/manifests/kustomize/overlays/istio/kustomization.yaml`
- `components/centraldashboard-angular/manifests/kustomize/overlays/kserve/kustomization.yaml`
- `components/profile-controller/manifests/kustomize/overlays/kubeflow/kustomization.yaml`

the previous 3 PRs for this issue ([#213](https://github.com/kubeflow/dashboard/pull/213), [#214](https://github.com/kubeflow/dashboard/pull/214), [#219](https://github.com/kubeflow/dashboard/pull/219)) were all closed without merge — they only updated the 3 `virtual-service.yaml` files and missed the 5 `kustomization.yaml` files whose `replacements[].targets[].select.version` fields also reference `v1alpha3`. without updating those selectors, `kustomize build` would fail to match the VirtualService resources for replacement.
