### PR TITLE
chore: audit access-management for k8s.io v0.35+ compatibility

### DIFF
--- a/components/access-management/kfam/api_default.go
+++ b/components/access-management/kfam/api_default.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )


### PR DESCRIPTION
closes #438

## Summary

Audits `components/access-management/` (KFAM) for compatibility with the dependency bump landed in #360. Note: `main` has since moved past what #438 described — this module is currently on Go 1.26, istio.io/api v1.30.3, k8s.io v0.36.3, and controller-runtime v0.24.1 (originally v0.35+/v0.23.3 at the time #438 was filed). PR #360 only migrated `profile-controller`'s source code; KFAM's `go.mod`/`go.sum`/`Dockerfile` were bumped but the source was never audited — this PR closes that gap.

Audit result: **no breaking API usage found**. `go build`, `go vet`, and `go test` all pass with no source changes required for compatibility. One dead import was removed as part of the "no deprecated API usage" acceptance criterion.

## Scope checked

| Area | Finding |
|---|---|
| `k8s.io/client-go` (scheme registration, REST client, informer patterns) | Compatible. `AddToScheme`, `rest.RESTClientFor`, `informers.NewSharedInformerFactory` all unchanged in v0.36.3. |
| `istio.io/client-go` scheme registration & type assertions (`main.go:24`) | Compatible. `istioSecurityClient.AddToScheme` unchanged. No type assertions on istio types exist in this module — only struct construction (`istioSecurity.AuthorizationPolicy{...}`). |
| `sigs.k8s.io/controller-runtime` inherited patterns | KFAM imports only `pkg/client/config` (`config.GetConfig()`), unchanged in v0.24.1. No `Manager`, `Watches`/`WatchesRawSource`, or `MapFunc` usage — the pattern that broke in `profile-controller` (#360) doesn't exist in this module. |

## Changes

| File | Change |
|---|---|
| `kfam/api_default.go` | Removed dead blank import `k8s.io/client-go/plugin/pkg/client/auth/gcp` — non-functional since client-go v1.26 (provider now just logs a removal notice at runtime). Kept alive only via its `init()` side effect; no longer needed. |

## Verification

- `go build ./...` passes locally
- `go vet ./...` clean
- `go test ./...` passes (`kfam` package tests green; other two packages have no test files)
- `go mod tidy` clean — no `go.mod`/`go.sum` changes (`golang.org/x/oauth2` remains as an indirect dependency required elsewhere in the graph, confirming it wasn't solely tied to the removed gcp plugin)

## Contributor Checklist

- [x] DCO sign-off
- [x] `go build ./...` passes
- [x] `go mod tidy` clean
- [x] Dockerfile Go version matches go.mod (1.26)
- [x] Only `components/access-management/` files modified