### PR TITLE
fix: preserve unrelated IAM trust policy statements

### DIFF
--- a/components/profile-controller/controllers/plugin_iam.go
+++ b/components/profile-controller/controllers/plugin_iam.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/go-logr/logr"
 	profilev1 "github.com/kubeflow/dashboard/components/profile-controller/api/v1"
-	"github.com/tidwall/gjson"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -138,6 +137,227 @@ func removeIAMRoleAnnotation(sa *corev1.ServiceAccount, iamRoleArn string) {
 	}
 }
 
+func statementHasAction(statement MapOfInterfaces, targetAction string) bool {
+	action, ok := statement["Action"]
+	if !ok {
+		return false
+	}
+	switch a := action.(type) {
+	case string:
+		return strings.EqualFold(a, targetAction)
+	case []interface{}:
+		for _, item := range a {
+			if str, ok := item.(string); ok && strings.EqualFold(str, targetAction) {
+				return true
+			}
+		}
+	case []string:
+		for _, item := range a {
+			if strings.EqualFold(item, targetAction) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func getStatementFederatedArn(statement MapOfInterfaces) string {
+	principal, ok := statement["Principal"]
+	if !ok {
+		return ""
+	}
+	pMap, ok := principal.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	fed, ok := pMap["Federated"]
+	if !ok {
+		return ""
+	}
+	fedStr, ok := fed.(string)
+	if !ok {
+		return ""
+	}
+	return fedStr
+}
+
+func stringEqualsMatches(val interface{}, target string) bool {
+	switch v := val.(type) {
+	case string:
+		return v == target
+	case []interface{}:
+		for _, item := range v {
+			if str, ok := item.(string); ok && str == target {
+				return true
+			}
+		}
+	case []string:
+		for _, item := range v {
+			if item == target {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func extractSubValues(val interface{}) []string {
+	var res []string
+	if val == nil {
+		return res
+	}
+	switch v := val.(type) {
+	case string:
+		if v != "" {
+			res = append(res, v)
+		}
+	case []interface{}:
+		for _, item := range v {
+			if str, ok := item.(string); ok && str != "" {
+				res = append(res, str)
+			}
+		}
+	case []string:
+		for _, str := range v {
+			if str != "" {
+				res = append(res, str)
+			}
+		}
+	}
+	return res
+}
+
+type oidcCandidate struct {
+	index               int
+	providerArn         string
+	issuerUrl           string
+	existingSubs        []string
+	containsTargetSA    bool
+	containsNamespaceSA bool
+}
+
+func findKubeflowOIDCStatementIndex(statements []MapOfInterfaces, namespace, serviceAccountName string, isRemove bool) (int, string, error) {
+	targetSA := fmt.Sprintf(AWS_TRUST_IDENTITY_SUBJECT, namespace, serviceAccountName)
+	nsPrefix := fmt.Sprintf("system:serviceaccount:%s:", namespace)
+
+	var candidates []oidcCandidate
+
+	for i, stmt := range statements {
+		fedArn := getStatementFederatedArn(stmt)
+		if fedArn == "" || !strings.Contains(fedArn, "oidc-provider/") {
+			continue
+		}
+		if !statementHasAction(stmt, "sts:AssumeRoleWithWebIdentity") {
+			continue
+		}
+		if eff, ok := stmt["Effect"].(string); ok && eff != "Allow" {
+			continue
+		}
+
+		issuerUrl := getIssuerUrlFromProviderArn(fedArn)
+		audKey := issuerUrl + ":aud"
+		subKey := issuerUrl + ":sub"
+
+		condMap, ok := stmt["Condition"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		strEqualsMap, ok := condMap["StringEquals"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// Must have aud == sts.amazonaws.com
+		if !stringEqualsMatches(strEqualsMap[audKey], AWS_DEFAULT_AUDIENCE) {
+			continue
+		}
+
+		// Extract existing subjects
+		subs := extractSubValues(strEqualsMap[subKey])
+
+		// Check if it has non-Kubernetes subjects (e.g. repo:org/repo:... for GitHub Actions)
+		hasNonK8sSubject := false
+		for _, sub := range subs {
+			if !strings.HasPrefix(sub, "system:serviceaccount:") {
+				hasNonK8sSubject = true
+				break
+			}
+		}
+		if hasNonK8sSubject {
+			// Disqualify third-party non-Kubernetes OIDC statements
+			continue
+		}
+
+		cand := oidcCandidate{
+			index:        i,
+			providerArn:  fedArn,
+			issuerUrl:    issuerUrl,
+			existingSubs: subs,
+		}
+
+		for _, sub := range subs {
+			if sub == targetSA {
+				cand.containsTargetSA = true
+			}
+			if strings.HasPrefix(sub, nsPrefix) {
+				cand.containsNamespaceSA = true
+			}
+		}
+
+		candidates = append(candidates, cand)
+	}
+
+	if isRemove {
+		var matched []oidcCandidate
+		for _, c := range candidates {
+			if c.containsTargetSA {
+				matched = append(matched, c)
+			}
+		}
+		if len(matched) == 0 {
+			// Target SA is not present in any candidate statement; this is an idempotent remove
+			return -1, "", nil
+		}
+		if len(matched) == 1 {
+			return matched[0].index, matched[0].providerArn, nil
+		}
+		return -1, "", fmt.Errorf("ambiguous trust policy: multiple candidate OIDC statements contain service account %s", targetSA)
+	}
+
+	// For Add:
+	// 1. Check idempotency: if target SA already present in any candidate statement
+	for _, c := range candidates {
+		if c.containsTargetSA {
+			return -1, "", &ConditionExistError{msg: fmt.Sprintf("service account %s already exists in trust policy", targetSA)}
+		}
+	}
+
+	// 2. If exactly one candidate already manages service accounts for this namespace
+	var nsMatched []oidcCandidate
+	for _, c := range candidates {
+		if c.containsNamespaceSA {
+			nsMatched = append(nsMatched, c)
+		}
+	}
+	if len(nsMatched) == 1 {
+		return nsMatched[0].index, nsMatched[0].providerArn, nil
+	}
+	if len(nsMatched) > 1 {
+		return -1, "", fmt.Errorf("ambiguous trust policy: multiple candidate OIDC statements contain service accounts for namespace %s", namespace)
+	}
+
+	// 3. Ambiguity evaluation on candidates
+	if len(candidates) == 0 {
+		return -1, "", errors.New("no matching OIDC trust statement found in trust policy")
+	}
+	if len(candidates) == 1 {
+		return candidates[0].index, candidates[0].providerArn, nil
+	}
+
+	// Multiple candidates exist and neither can be uniquely proven to be the Kubeflow statement
+	return -1, "", fmt.Errorf("ambiguous trust policy: found %d candidate OIDC statements; cannot safely determine Kubeflow-managed statement", len(candidates))
+}
+
 // add serviceAccountNamespace/serviceAccountName in assumeRolePolicy
 func addServiceAccountInAssumeRolePolicy(policyDocument, serviceAccountNamespace, serviceAccountName string) (string, error) {
 	var oldDoc MapOfInterfaces
@@ -150,45 +370,58 @@ func addServiceAccountInAssumeRolePolicy(policyDocument, serviceAccountNamespace
 	if err != nil {
 		return "", err
 	}
-	json.Unmarshal(statementInBytes, &statements)
-
-	oidcRoleArn := gjson.Get(policyDocument, "Statement.0.Principal.Federated").String()
-	issuerUrlWithProtocol := getIssuerUrlFromProviderArn(oidcRoleArn)
-
-	key := fmt.Sprintf("%s:sub", issuerUrlWithProtocol)
-	trustIdentity := fmt.Sprintf(AWS_TRUST_IDENTITY_SUBJECT, serviceAccountNamespace, serviceAccountName)
-
-	// We assume we only operator on first statement, don't add/remove new statement
-	statement := statements[0]
-	statementInBytes, err = json.Marshal(statement)
-	if err != nil {
+	if err := json.Unmarshal(statementInBytes, &statements); err != nil {
 		return "", err
 	}
-	identities := gjson.Get(string(statementInBytes), "Condition.StringEquals").Map()
 
-	var originalIdentities []string
-	val, ok := identities[key]
-	if ok {
-		for _, identity := range val.Array() {
-			if identity.Str == trustIdentity {
-				// check if trustIdentity is in the list, if so, we skip add it
-				return policyDocument, &ConditionExistError{}
-			}
-			originalIdentities = append(originalIdentities, identity.Str)
-		}
+	targetIdx, oidcRoleArn, err := findKubeflowOIDCStatementIndex(statements, serviceAccountNamespace, serviceAccountName, false)
+	if err != nil {
+		return policyDocument, err
 	}
 
-	// add new serviceAccountNamespace/serviceAccountName record
-	originalIdentities = append(originalIdentities, fmt.Sprintf(AWS_TRUST_IDENTITY_SUBJECT, serviceAccountNamespace, serviceAccountName))
-	document := MakeAssumeRoleWithWebIdentityPolicyDocument(oidcRoleArn, MapOfInterfaces{
-		"StringEquals": map[string][]string{
-			issuerUrlWithProtocol + ":aud": []string{AWS_DEFAULT_AUDIENCE},
-			issuerUrlWithProtocol + ":sub": originalIdentities,
-		},
-	})
+	issuerUrlWithProtocol := getIssuerUrlFromProviderArn(oidcRoleArn)
+	subKey := fmt.Sprintf("%s:sub", issuerUrlWithProtocol)
+	audKey := fmt.Sprintf("%s:aud", issuerUrlWithProtocol)
+	trustIdentity := fmt.Sprintf(AWS_TRUST_IDENTITY_SUBJECT, serviceAccountNamespace, serviceAccountName)
 
-	newAssumeRolePolicyDocument := MakePolicyDocument(document)
-	newPolicyDoc, err := json.Marshal(newAssumeRolePolicyDocument)
+	stmt := statements[targetIdx]
+
+	condObj, ok := stmt["Condition"]
+	var condMap map[string]interface{}
+	if ok && condObj != nil {
+		condMap, _ = condObj.(map[string]interface{})
+	}
+	if condMap == nil {
+		condMap = make(map[string]interface{})
+		stmt["Condition"] = condMap
+	}
+
+	strEqObj, ok := condMap["StringEquals"]
+	var strEqMap map[string]interface{}
+	if ok && strEqObj != nil {
+		strEqMap, _ = strEqObj.(map[string]interface{})
+	}
+	if strEqMap == nil {
+		strEqMap = make(map[string]interface{})
+		condMap["StringEquals"] = strEqMap
+	}
+
+	if _, ok := strEqMap[audKey]; !ok {
+		strEqMap[audKey] = []string{AWS_DEFAULT_AUDIENCE}
+	}
+
+	existingSubs := extractSubValues(strEqMap[subKey])
+	for _, id := range existingSubs {
+		if id == trustIdentity {
+			return policyDocument, &ConditionExistError{}
+		}
+	}
+	existingSubs = append(existingSubs, trustIdentity)
+	strEqMap[subKey] = existingSubs
+
+	statements[targetIdx] = stmt
+	oldDoc["Statement"] = statements
+	newPolicyDoc, err := json.Marshal(oldDoc)
 	if err != nil {
 		return "", err
 	}
@@ -197,58 +430,68 @@ func addServiceAccountInAssumeRolePolicy(policyDocument, serviceAccountNamespace
 
 func removeServiceAccountInAssumeRolePolicy(policyDocument, serviceAccountNamespace, serviceAccountName string) (string, error) {
 	var oldDoc MapOfInterfaces
-	json.Unmarshal([]byte(policyDocument), &oldDoc)
+	err := json.Unmarshal([]byte(policyDocument), &oldDoc)
+	if err != nil {
+		return "", err
+	}
 	var statements []MapOfInterfaces
 	statementInBytes, err := json.Marshal(oldDoc["Statement"])
 	if err != nil {
 		return "", err
 	}
-	json.Unmarshal(statementInBytes, &statements)
-
-	oidcRoleArn := gjson.Get(policyDocument, "Statement.0.Principal.Federated").String()
-	issuerUrlWithProtocol := getIssuerUrlFromProviderArn(oidcRoleArn)
-
-	key := fmt.Sprintf("%s:sub", issuerUrlWithProtocol)
-	trustIdentity := fmt.Sprintf(AWS_TRUST_IDENTITY_SUBJECT, serviceAccountNamespace, serviceAccountName)
-	statement := statements[0]
-
-	statementInBytes, err = json.Marshal(statement)
-	if err != nil {
+	if err := json.Unmarshal(statementInBytes, &statements); err != nil {
 		return "", err
 	}
-	identities := gjson.Get(string(statementInBytes), "Condition.StringEquals").Map()
 
-	var newIdentities []string
-	val, ok := identities[key]
-	if ok {
-		for _, identity := range val.Array() {
-			if identity.Str != trustIdentity {
-				newIdentities = append(newIdentities, identity.Str)
-			}
+	targetIdx, oidcRoleArn, err := findKubeflowOIDCStatementIndex(statements, serviceAccountNamespace, serviceAccountName, true)
+	if err != nil {
+		return policyDocument, err
+	}
+	if targetIdx == -1 {
+		return policyDocument, nil
+	}
+
+	issuerUrlWithProtocol := getIssuerUrlFromProviderArn(oidcRoleArn)
+	subKey := fmt.Sprintf("%s:sub", issuerUrlWithProtocol)
+	trustIdentity := fmt.Sprintf(AWS_TRUST_IDENTITY_SUBJECT, serviceAccountNamespace, serviceAccountName)
+
+	stmt := statements[targetIdx]
+
+	condObj, ok := stmt["Condition"]
+	var condMap map[string]interface{}
+	if ok && condObj != nil {
+		condMap, _ = condObj.(map[string]interface{})
+	}
+	if condMap == nil {
+		return policyDocument, nil
+	}
+
+	strEqObj, ok := condMap["StringEquals"]
+	var strEqMap map[string]interface{}
+	if ok && strEqObj != nil {
+		strEqMap, _ = strEqObj.(map[string]interface{})
+	}
+	if strEqMap == nil {
+		return policyDocument, nil
+	}
+
+	existingSubs := extractSubValues(strEqMap[subKey])
+	var newSubs []string
+	for _, id := range existingSubs {
+		if id != trustIdentity {
+			newSubs = append(newSubs, id)
 		}
 	}
 
-	// The reason we use this way is because if newIdentities is empty and Marshal will give a null which break policy regulation
-	var conditions MapOfInterfaces
-	if len(newIdentities) == 0 {
-		conditions = MapOfInterfaces{
-			"StringEquals": map[string][]string{
-				issuerUrlWithProtocol + ":aud": []string{AWS_DEFAULT_AUDIENCE},
-			},
-		}
+	if len(newSubs) == 0 {
+		delete(strEqMap, subKey)
 	} else {
-		conditions = MapOfInterfaces{
-			"StringEquals": map[string][]string{
-				issuerUrlWithProtocol + ":aud": []string{AWS_DEFAULT_AUDIENCE},
-				issuerUrlWithProtocol + ":sub": newIdentities,
-			},
-		}
+		strEqMap[subKey] = newSubs
 	}
 
-	document := MakeAssumeRoleWithWebIdentityPolicyDocument(oidcRoleArn, conditions)
-
-	newAssumeRolePolicyDocument := MakePolicyDocument(document)
-	newPolicyDoc, err := json.Marshal(newAssumeRolePolicyDocument)
+	statements[targetIdx] = stmt
+	oldDoc["Statement"] = statements
+	newPolicyDoc, err := json.Marshal(oldDoc)
 	if err != nil {
 		return "", err
 	}

--- a/components/profile-controller/controllers/plugin_iam_test.go
+++ b/components/profile-controller/controllers/plugin_iam_test.go
@@ -237,7 +237,9 @@ func TestRemoveServiceAccountInAssumeRolePolicy(t *testing.T) {
 					  "Principal": {
 						"Federated": "arn:aws:iam::34892524:oidc-provider/oidc.beta.us-west-2.wesley.amazonaws.com/id/50D94CFC65139194EDC21891B611EF72"
 					  },
-					  "Action": "sts:AssumeRoleWithWebIdentity",
+					  "Action": [
+						"sts:AssumeRoleWithWebIdentity"
+					  ],
 					  "Condition": {
 						"StringEquals": {
 						  "oidc.beta.us-west-2.wesley.amazonaws.com/id/50D94CFC65139194EDC21891B611EF72:aud": ["sts.amazonaws.com"],
@@ -281,7 +283,9 @@ func TestRemoveServiceAccountInAssumeRolePolicy(t *testing.T) {
 					  "Principal": {
 						"Federated": "arn:aws:iam::34892524:oidc-provider/oidc.beta.us-west-2.wesley.amazonaws.com/id/50D94CFC65139194EDC21891B611EF72"
 					  },
-					  "Action": "sts:AssumeRoleWithWebIdentity",
+					  "Action": [
+						"sts:AssumeRoleWithWebIdentity"
+					  ],
 					  "Condition": {
 						"StringEquals": {
 						  "oidc.beta.us-west-2.wesley.amazonaws.com/id/50D94CFC65139194EDC21891B611EF72:aud": ["sts.amazonaws.com"]
@@ -310,4 +314,907 @@ func TestIsAnnotateOnly(t *testing.T) {
 	aws = &AwsIAMForServiceAccount{AnnotateOnly: false}
 	// Check that the result is true
 	assert.False(t, aws.isAnnotateOnly())
+}
+
+// ==============================================================================
+// GitHub Issue #453 Regression Test Matrix (12 Test Cases)
+// ==============================================================================
+
+// Case 1: Single Kubeflow OIDC statement (baseline)
+func TestIssue453_Case1_SingleKubeflowOIDCStatement(t *testing.T) {
+	policy := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com"
+					}
+				}
+			}
+		]
+	}`
+
+	expected := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com",
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:sub": ["system:serviceaccount:kubeflow-user:default-editor"]
+					}
+				}
+			}
+		]
+	}`
+
+	result, err := addServiceAccountInAssumeRolePolicy(policy, "kubeflow-user", "default-editor")
+	require.NoError(t, err)
+	require.JSONEq(t, expected, result)
+}
+
+// Case 2: Kubeflow statement at index 1 (ordering independence)
+func TestIssue453_Case2_KubeflowStatementAtIndex1(t *testing.T) {
+	policy := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "UnrelatedStatement",
+				"Effect": "Allow",
+				"Principal": {
+					"AWS": "arn:aws:iam::123456789012:role/other-role"
+				},
+				"Action": "sts:AssumeRole"
+			},
+			{
+				"Sid": "KubeflowStatement",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": ["sts.amazonaws.com"]
+					}
+				}
+			}
+		]
+	}`
+
+	expected := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "UnrelatedStatement",
+				"Effect": "Allow",
+				"Principal": {
+					"AWS": "arn:aws:iam::123456789012:role/other-role"
+				},
+				"Action": "sts:AssumeRole"
+			},
+			{
+				"Sid": "KubeflowStatement",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": ["sts.amazonaws.com"],
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:sub": ["system:serviceaccount:ns1:sa1"]
+					}
+				}
+			}
+		]
+	}`
+
+	result, err := addServiceAccountInAssumeRolePolicy(policy, "ns1", "sa1")
+	require.NoError(t, err)
+	require.JSONEq(t, expected, result)
+}
+
+// Case 3: Unrelated AWS trust statement preserved
+func TestIssue453_Case3_UnrelatedAWSTrustStatement(t *testing.T) {
+	policy := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "AWSTrust",
+				"Effect": "Allow",
+				"Principal": {
+					"AWS": "arn:aws:iam::123456789012:root"
+				},
+				"Action": "sts:AssumeRole"
+			},
+			{
+				"Sid": "EKSIRSA",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com",
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:sub": ["system:serviceaccount:ns1:sa1"]
+					}
+				}
+			}
+		]
+	}`
+
+	// Remove SA: AWS trust statement must remain
+	removeResult, err := removeServiceAccountInAssumeRolePolicy(policy, "ns1", "sa1")
+	require.NoError(t, err)
+
+	expectedRemove := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "AWSTrust",
+				"Effect": "Allow",
+				"Principal": {
+					"AWS": "arn:aws:iam::123456789012:root"
+				},
+				"Action": "sts:AssumeRole"
+			},
+			{
+				"Sid": "EKSIRSA",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com"
+					}
+				}
+			}
+		]
+	}`
+	require.JSONEq(t, expectedRemove, removeResult)
+}
+
+// Case 4: Unrelated OIDC statement before Kubeflow (GitHub Actions)
+func TestIssue453_Case4_UnrelatedOIDCBeforeKubeflow(t *testing.T) {
+	policy := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "GitHubActionsOIDC",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+						"token.actions.githubusercontent.com:sub": "repo:my-org/my-repo:ref:refs/heads/main"
+					}
+				}
+			},
+			{
+				"Sid": "KubeflowOIDC",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com"
+					}
+				}
+			}
+		]
+	}`
+
+	expected := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "GitHubActionsOIDC",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+						"token.actions.githubusercontent.com:sub": "repo:my-org/my-repo:ref:refs/heads/main"
+					}
+				}
+			},
+			{
+				"Sid": "KubeflowOIDC",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com",
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:sub": ["system:serviceaccount:kubeflow-test:default-editor"]
+					}
+				}
+			}
+		]
+	}`
+
+	result, err := addServiceAccountInAssumeRolePolicy(policy, "kubeflow-test", "default-editor")
+	require.NoError(t, err)
+	require.JSONEq(t, expected, result)
+}
+
+// Case 5: Unrelated OIDC statement after Kubeflow (GitHub Actions)
+func TestIssue453_Case5_UnrelatedOIDCAfterKubeflow(t *testing.T) {
+	policy := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "KubeflowOIDC",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com"
+					}
+				}
+			},
+			{
+				"Sid": "GitHubActionsOIDC",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+						"token.actions.githubusercontent.com:sub": "repo:my-org/my-repo:ref:refs/heads/main"
+					}
+				}
+			}
+		]
+	}`
+
+	expected := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "KubeflowOIDC",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com",
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:sub": ["system:serviceaccount:kubeflow-test:default-editor"]
+					}
+				}
+			},
+			{
+				"Sid": "GitHubActionsOIDC",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+						"token.actions.githubusercontent.com:sub": "repo:my-org/my-repo:ref:refs/heads/main"
+					}
+				}
+			}
+		]
+	}`
+
+	result, err := addServiceAccountInAssumeRolePolicy(policy, "kubeflow-test", "default-editor")
+	require.NoError(t, err)
+	require.JSONEq(t, expected, result)
+}
+
+// Case 6: Multiple OIDC statements disambiguated by existing namespace service accounts
+func TestIssue453_Case6_MultipleOIDCStatementsDisambiguated(t *testing.T) {
+	policy := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "EKSClusterA",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_A"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_A:aud": "sts.amazonaws.com",
+						"oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_A:sub": ["system:serviceaccount:ns-alpha:editor"]
+					}
+				}
+			},
+			{
+				"Sid": "EKSClusterB",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_B"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_B:aud": "sts.amazonaws.com",
+						"oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_B:sub": ["system:serviceaccount:ns-beta:viewer"]
+					}
+				}
+			}
+		]
+	}`
+
+	// Adding sa to ns-alpha: must choose ClusterA
+	addResult, err := addServiceAccountInAssumeRolePolicy(policy, "ns-alpha", "viewer")
+	require.NoError(t, err)
+
+	expectedAdd := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "EKSClusterA",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_A"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_A:aud": "sts.amazonaws.com",
+						"oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_A:sub": [
+							"system:serviceaccount:ns-alpha:editor",
+							"system:serviceaccount:ns-alpha:viewer"
+						]
+					}
+				}
+			},
+			{
+				"Sid": "EKSClusterB",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_B"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_B:aud": "sts.amazonaws.com",
+						"oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_B:sub": ["system:serviceaccount:ns-beta:viewer"]
+					}
+				}
+			}
+		]
+	}`
+	require.JSONEq(t, expectedAdd, addResult)
+}
+
+// Case 7: Ambiguous multiple OIDC statements -> safe failure with policy unchanged
+func TestIssue453_Case7_AmbiguousMultipleOIDCStatements(t *testing.T) {
+	policy := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "ClusterA",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_A"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_A:aud": "sts.amazonaws.com"
+					}
+				}
+			},
+			{
+				"Sid": "ClusterB",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_B"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_B:aud": "sts.amazonaws.com"
+					}
+				}
+			}
+		]
+	}`
+
+	result, err := addServiceAccountInAssumeRolePolicy(policy, "new-ns", "default-editor")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous trust policy")
+	// Policy must be returned unchanged
+	require.JSONEq(t, policy, result)
+}
+
+// Case 8: Existing custom fields on target statement are preserved
+func TestIssue453_Case8_ExistingCustomFieldsOnTargetStatementPreserved(t *testing.T) {
+	policy := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "CustomMySid123",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": [
+					"sts:AssumeRoleWithWebIdentity"
+				],
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com"
+					},
+					"StringLike": {
+						"aws:PrincipalTag/Department": "MachineLearning"
+					}
+				}
+			}
+		]
+	}`
+
+	expected := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "CustomMySid123",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": [
+					"sts:AssumeRoleWithWebIdentity"
+				],
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com",
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:sub": ["system:serviceaccount:ns1:sa1"]
+					},
+					"StringLike": {
+						"aws:PrincipalTag/Department": "MachineLearning"
+					}
+				}
+			}
+		]
+	}`
+
+	result, err := addServiceAccountInAssumeRolePolicy(policy, "ns1", "sa1")
+	require.NoError(t, err)
+	require.JSONEq(t, expected, result)
+}
+
+// Case 9: Add preserves every unrelated statement
+func TestIssue453_Case9_AddPreservesEveryUnrelatedStatement(t *testing.T) {
+	policy := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "IAMRoleTrust",
+				"Effect": "Allow",
+				"Principal": {
+					"AWS": "arn:aws:iam::123456789012:role/admin-role"
+				},
+				"Action": "sts:AssumeRole"
+			},
+			{
+				"Sid": "SAMLTrust",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:saml-provider/MyOkta"
+				},
+				"Action": "sts:AssumeRoleWithSAML",
+				"Condition": {
+					"StringEquals": {
+						"SAML:aud": "https://signin.aws.amazon.com/saml"
+					}
+				}
+			},
+			{
+				"Sid": "KubeflowIRSA",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com"
+					}
+				}
+			}
+		]
+	}`
+
+	expected := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "IAMRoleTrust",
+				"Effect": "Allow",
+				"Principal": {
+					"AWS": "arn:aws:iam::123456789012:role/admin-role"
+				},
+				"Action": "sts:AssumeRole"
+			},
+			{
+				"Sid": "SAMLTrust",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:saml-provider/MyOkta"
+				},
+				"Action": "sts:AssumeRoleWithSAML",
+				"Condition": {
+					"StringEquals": {
+						"SAML:aud": "https://signin.aws.amazon.com/saml"
+					}
+				}
+			},
+			{
+				"Sid": "KubeflowIRSA",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com",
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:sub": ["system:serviceaccount:ns1:sa1"]
+					}
+				}
+			}
+		]
+	}`
+
+	result, err := addServiceAccountInAssumeRolePolicy(policy, "ns1", "sa1")
+	require.NoError(t, err)
+	require.JSONEq(t, expected, result)
+}
+
+// Case 10: Remove preserves every unrelated statement
+func TestIssue453_Case10_RemovePreservesEveryUnrelatedStatement(t *testing.T) {
+	policy := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "IAMRoleTrust",
+				"Effect": "Allow",
+				"Principal": {
+					"AWS": "arn:aws:iam::123456789012:role/admin-role"
+				},
+				"Action": "sts:AssumeRole"
+			},
+			{
+				"Sid": "SAMLTrust",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:saml-provider/MyOkta"
+				},
+				"Action": "sts:AssumeRoleWithSAML",
+				"Condition": {
+					"StringEquals": {
+						"SAML:aud": "https://signin.aws.amazon.com/saml"
+					}
+				}
+			},
+			{
+				"Sid": "KubeflowIRSA",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com",
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:sub": ["system:serviceaccount:ns1:sa1"]
+					}
+				}
+			}
+		]
+	}`
+
+	expected := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "IAMRoleTrust",
+				"Effect": "Allow",
+				"Principal": {
+					"AWS": "arn:aws:iam::123456789012:role/admin-role"
+				},
+				"Action": "sts:AssumeRole"
+			},
+			{
+				"Sid": "SAMLTrust",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:saml-provider/MyOkta"
+				},
+				"Action": "sts:AssumeRoleWithSAML",
+				"Condition": {
+					"StringEquals": {
+						"SAML:aud": "https://signin.aws.amazon.com/saml"
+					}
+				}
+			},
+			{
+				"Sid": "KubeflowIRSA",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com"
+					}
+				}
+			}
+		]
+	}`
+
+	result, err := removeServiceAccountInAssumeRolePolicy(policy, "ns1", "sa1")
+	require.NoError(t, err)
+	require.JSONEq(t, expected, result)
+}
+
+// Case 11: Add is idempotent
+func TestIssue453_Case11_AddIdempotency(t *testing.T) {
+	policy := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com",
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:sub": ["system:serviceaccount:ns1:sa1"]
+					}
+				}
+			}
+		]
+	}`
+
+	result, err := addServiceAccountInAssumeRolePolicy(policy, "ns1", "sa1")
+	require.Error(t, err)
+	assert.IsType(t, &ConditionExistError{}, err)
+	require.JSONEq(t, policy, result)
+}
+
+// Case 12: Remove absent service account leaves policy intact
+func TestIssue453_Case12_RemoveAbsentServiceAccount(t *testing.T) {
+	policy := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com",
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:sub": ["system:serviceaccount:ns1:sa1"]
+					}
+				}
+			}
+		]
+	}`
+
+	result, err := removeServiceAccountInAssumeRolePolicy(policy, "ns1", "absent-sa")
+	require.NoError(t, err)
+	require.JSONEq(t, policy, result)
+}
+
+// ==============================================================================
+// Additional Adversarial Multi-OIDC & Symmetry Tests
+// ==============================================================================
+
+// Adversarial Test: GitLab CI OIDC provider alongside Kubeflow EKS OIDC
+func TestIssue453_Adversarial_GitLabCIOIDC(t *testing.T) {
+	policy := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "GitLabCIOIDC",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/gitlab.com"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"gitlab.com:aud": "sts.amazonaws.com",
+						"gitlab.com:sub": "project_path:my-group/my-project:ref_type:branch:ref:main"
+					}
+				}
+			},
+			{
+				"Sid": "KubeflowEKS",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com"
+					}
+				}
+			}
+		]
+	}`
+
+	expected := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "GitLabCIOIDC",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/gitlab.com"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"gitlab.com:aud": "sts.amazonaws.com",
+						"gitlab.com:sub": "project_path:my-group/my-project:ref_type:branch:ref:main"
+					}
+				}
+			},
+			{
+				"Sid": "KubeflowEKS",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/11223344"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:aud": "sts.amazonaws.com",
+						"oidc.eks.us-west-2.amazonaws.com/id/11223344:sub": ["system:serviceaccount:kf-user:default-editor"]
+					}
+				}
+			}
+		]
+	}`
+
+	result, err := addServiceAccountInAssumeRolePolicy(policy, "kf-user", "default-editor")
+	require.NoError(t, err)
+	require.JSONEq(t, expected, result)
+}
+
+// Adversarial Test: Multiple EKS statements with overlapping namespace subjects -> safe failure
+func TestIssue453_Adversarial_MultipleEKSOverlappingNamespace(t *testing.T) {
+	policy := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "ClusterA",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_A"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_A:aud": "sts.amazonaws.com",
+						"oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_A:sub": ["system:serviceaccount:shared-ns:sa-one"]
+					}
+				}
+			},
+			{
+				"Sid": "ClusterB",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_B"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_B:aud": "sts.amazonaws.com",
+						"oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_B:sub": ["system:serviceaccount:shared-ns:sa-two"]
+					}
+				}
+			}
+		]
+	}`
+
+	// Adding sa-three to shared-ns: both clusters already have service accounts for shared-ns
+	result, err := addServiceAccountInAssumeRolePolicy(policy, "shared-ns", "sa-three")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous trust policy: multiple candidate OIDC statements contain service accounts for namespace shared-ns")
+	// Policy must be returned untouched
+	require.JSONEq(t, policy, result)
+}
+
+// Adversarial Test: Add and Remove roundtrip symmetry
+func TestIssue453_Adversarial_AddRemoveRoundTrip(t *testing.T) {
+	originalPolicy := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "IAMTrust",
+				"Effect": "Allow",
+				"Principal": {
+					"AWS": "arn:aws:iam::123456789012:role/ci-role"
+				},
+				"Action": "sts:AssumeRole"
+			},
+			{
+				"Sid": "GHActions",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+						"token.actions.githubusercontent.com:sub": "repo:org/repo:ref:refs/heads/main"
+					}
+				}
+			},
+			{
+				"Sid": "KubeflowEKS",
+				"Effect": "Allow",
+				"Principal": {
+					"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_1"
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"oidc.eks.us-west-2.amazonaws.com/id/CLUSTER_1:aud": "sts.amazonaws.com"
+					}
+				}
+			}
+		]
+	}`
+
+	// Step 1: Add service account
+	addedPolicy, err := addServiceAccountInAssumeRolePolicy(originalPolicy, "my-ns", "editor")
+	require.NoError(t, err)
+
+	// Step 2: Remove same service account
+	removedPolicy, err := removeServiceAccountInAssumeRolePolicy(addedPolicy, "my-ns", "editor")
+	require.NoError(t, err)
+
+	// Result must be strictly identical to originalPolicy
+	require.JSONEq(t, originalPolicy, removedPolicy)
 }


### PR DESCRIPTION
<!-- Reference the issue -->
closes: #453

### What this PR does / why we need it:
Fixes #453. When configuring AWS IRSA for Profile service accounts, the Profile Controller previously reconstructed single-statement policy documents, silently discarding unrelated IAM trust policy statements and custom fields.

This PR updates the IAM plugin to:
- Mutate trust policies in-place on the existing `AssumeRolePolicyDocument`, preserving all unrelated statements (IAM roles, SAML providers, third-party OIDC providers).
- Preserve existing statement metadata including custom `Sid`, `Effect`, `Action` representation (array vs string), `Principal`, and extra condition blocks (`StringLike`, tags).
- Implement structural candidate matching (`findKubeflowOIDCStatementIndex`) using Action, Principal.Federated, and Condition without relying on statement ordering or index 0.
- Disqualify third-party OIDC statements containing non-Kubernetes subjects (e.g. GitHub Actions, GitLab CI).
- Add strict ambiguity guards to fail safely and return the policy unchanged if multiple candidate OIDC statements cannot be uniquely distinguished.
- Maintain full idempotency on add and remove.

### Special notes for your reviewer:
- No CRD, API, or manifest changes.
- No new dependencies added (`gjson` removed from `plugin_iam.go`).
- Includes a comprehensive 15-case regression and adversarial test suite in `plugin_iam_test.go`.

### AI Assistance Disclosure:
*Code implementation, test matrix design, and review were authored with the assistance of AI pair-programming tools and verified through automated test suites.*
>